### PR TITLE
Fix ontology version IRI and crash on OWL exports

### DIFF
--- a/eddy/core/exporters/owl2.py
+++ b/eddy/core/exporters/owl2.py
@@ -1913,7 +1913,7 @@ class OWLOntologyExporterWorker(AbstractWorker):
             self.finished.emit()
 
 
-class OWLOntologyFetcher:
+class OWLOntologyFetcher(AbstractWorker):
 
     def __init__(self, project, **kwargs):
         """
@@ -3908,3 +3908,4 @@ class OWLOntologyFetcher:
             LOGGER.debug('OWL 2 fetch could be completed')
         finally:
             detach()
+            self.finished.emit()

--- a/eddy/core/exporters/owl2.py
+++ b/eddy/core/exporters/owl2.py
@@ -1170,14 +1170,14 @@ class OWLOntologyExporterWorker(AbstractWorker):
         Generate a OWL 2 annotation axiom as rdfs:comment.
         :type node: AbstractNode
         """
-        text = QtWidgets.QTextEdit()
+        text = QtGui.QTextDocument()
 
         if OWLAxiom.Annotation in self.axiomsList:
             meta = self.project.meta(node.type(), node.text())
             if meta and not isEmpty(meta.get(K_DESCRIPTION, '')):
 
                 aproperty = self.df.getOWLAnnotationProperty(self.IRI.create("http://www.w3.org/2000/01/rdf-schema#comment"))
-                text.setText(meta.get(K_DESCRIPTION, ''))
+                text.setHtml(meta.get(K_DESCRIPTION, ''))
 
                 value = self.df.getOWLLiteral(OWLAnnotationText(text.toPlainText()))
                 value = cast(self.OWLAnnotationValue, value)
@@ -1197,7 +1197,7 @@ class OWLOntologyExporterWorker(AbstractWorker):
 
             if meta and not isEmpty(meta.get(K_DESCRIPTION, '')):
                 strDescription = meta.get(K_DESCRIPTION, '')
-                convHTML = QtWidgets.QTextBrowser()
+                convHTML = QtGui.QTextDocument()
                 convHTML.setHtml(strDescription)
                 strDescriptionHTML = convHTML.toHtml()
                 filterDescription = re.sub(r'^.*?<body', "<OntologyDescription", strDescriptionHTML, flags=re.DOTALL)
@@ -1242,7 +1242,7 @@ class OWLOntologyExporterWorker(AbstractWorker):
 
             if meta and not isEmpty(meta.get(K_DESCRIPTION, '')):
                 strDescription = meta.get(K_DESCRIPTION, '')
-                strPlain = QtWidgets.QTextEdit()
+                strPlain = QtGui.QTextDocument()
                 strPlain.setHtml(strDescription)
                 descPlain= strPlain.toPlainText()
 

--- a/eddy/core/exporters/owl2.py
+++ b/eddy/core/exporters/owl2.py
@@ -1684,7 +1684,7 @@ class OWLOntologyExporterWorker(AbstractWorker):
 
             ontologyIRI = rstrip(self.project.iri, '#')
             mastroIRI = rstrip('http://www.obdasystems.com/mastrostudio', '#')
-            versionIRI = '{0}/{1}'.format(ontologyIRI, self.project.version)
+            versionIRI = '{0}{1}{2}'.format(ontologyIRI, '' if ontologyIRI.endswith('/') else '/', self.project.version)
             ontologyID = self.OWLOntologyID(self.IRI.create(ontologyIRI), self.IRI.create(versionIRI))
             self.man = self.OWLManager.createOWLOntologyManager()
             self.df = self.man.getOWLDataFactory()
@@ -3639,7 +3639,7 @@ class OWLOntologyFetcher:
             #################################
 
             ontologyIRI = rstrip(self.project.iri, '#')
-            versionIRI = '{0}/{1}'.format(ontologyIRI, self.project.version)
+            versionIRI = '{0}{1}{2}'.format(ontologyIRI, '' if ontologyIRI.endswith('/') else '/', self.project.version)
             ontologyID = self.OWLOntologyID(self.IRI.create(ontologyIRI), self.IRI.create(versionIRI))
             self.man = self.OWLManager.createOWLOntologyManager()
             self.df = self.man.getOWLDataFactory()

--- a/eddy/ui/properties.py
+++ b/eddy/ui/properties.py
@@ -373,7 +373,7 @@ class NodeProperty(PropertyDialog):
         self.mainLayout.addWidget(self.mainWidget)
         self.mainLayout.addWidget(self.confirmationBox, 0, QtCore.Qt.AlignRight)
 
-        self.setWindowTitle('Properties: {0}'.format(self.node))
+        self.setWindowTitle('Properties: {0}'.format(self.node.text().replace('\n', '')))
         self.setWindowIcon(QtGui.QIcon(':/icons/128/ic_eddy'))
 
         connect(self.confirmationBox.accepted, self.complete)


### PR DESCRIPTION
This pull request introduces the following changes:
 * Fix double slash in version IRI when the ontology IRI already ends with a slash. Closes issue 458.
 * Fix crash on OWL export due to UI objects receiving signals after being deallocated. Closes issue 459.
 * Fix line feed characters appearing in properties dialog title.