### PR TITLE
JVM API to abstract from Java bridging libraries

### DIFF
--- a/eddy/__main__.py
+++ b/eddy/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 ##########################################################################
@@ -33,11 +32,11 @@
 #                                                                        #
 ##########################################################################
 
-"""Launcher script for Eddy."""
+"""Entry point for Eddy."""
 
 import sys
 
-from eddy.core.application import main
+from .core.application import main
 
 if __name__ == '__main__':
-    sys.exit(main())
+   sys.exit(main())

--- a/eddy/core/exporters/owl2.py
+++ b/eddy/core/exporters/owl2.py
@@ -3966,11 +3966,9 @@ class OWLOntologyFetcher(AbstractWorker):
             #################################
 
             if len(self._axiom_to_node_or_edge) != len(self._axioms):
-
                 LOGGER.error('len(_axiom_to_node_or_edge) != len(_axioms)')
                 LOGGER.error('len(_axiom_to_node_or_edge)',len(self._axiom_to_node_or_edge))
                 LOGGER.error('len(self._axioms)',len(self._axioms))
-                sys.exit(0)
 
             #############################################
             # REFINE THE KEYS OF THE DICTIONARY(CAST WITH OWLClass + .toString() ), remove duplicate entries

--- a/eddy/core/jvm.py
+++ b/eddy/core/jvm.py
@@ -1,0 +1,613 @@
+# -*- coding: utf-8 -*-
+
+##########################################################################
+#                                                                        #
+#  Eddy: a graphical editor for the specification of Graphol ontologies  #
+#  Copyright (C) 2015 Daniele Pantaleone <danielepantaleone@me.com>      #
+#                                                                        #
+#  This program is free software: you can redistribute it and/or modify  #
+#  it under the terms of the GNU General Public License as published by  #
+#  the Free Software Foundation, either version 3 of the License, or     #
+#  (at your option) any later version.                                   #
+#                                                                        #
+#  This program is distributed in the hope that it will be useful,       #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+#  GNU General Public License for more details.                          #
+#                                                                        #
+#  You should have received a copy of the GNU General Public License     #
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.  #
+#                                                                        #
+#  #####################                          #####################  #
+#                                                                        #
+#  Graphol is developed by members of the DASI-lab group of the          #
+#  Dipartimento di Ingegneria Informatica, Automatica e Gestionale       #
+#  A.Ruberti at Sapienza University of Rome: http://www.dis.uniroma1.it  #
+#                                                                        #
+#     - Domenico Lembo <lembo@dis.uniroma1.it>                           #
+#     - Valerio Santarelli <santarelli@dis.uniroma1.it>                  #
+#     - Domenico Fabio Savo <savo@dis.uniroma1.it>                       #
+#     - Daniele Pantaleone <pantaleone@dis.uniroma1.it>                  #
+#     - Marco Console <console@dis.uniroma1.it>                          #
+#                                                                        #
+##########################################################################
+
+"""This module is a thin wrapper around JNI libraries and is intended to abstract the API related to the JVM support"""
+
+import os
+import sys
+from enum import unique
+
+from eddy.core.datatypes.common import Enum_
+from eddy.core.functions.path import expandPath
+
+_LINUX = sys.platform.startswith('linux')
+_MACOS = sys.platform.startswith('darwin')
+_WIN32 = sys.platform.startswith('win32')
+
+_jvmLibraries = []
+_jvmClasspath = []
+_jvmOptions = []
+
+
+@unique
+class JVMJNILib(Enum_):
+    JNIUS = 'jnius'
+    JPYPE = 'jpype'
+
+
+def isJVMAvailable():
+    """
+    Returns True if there is at least one avaiable JNI wrapper library.
+
+    :rtype: bool
+    """
+    return len(_jvmLibraries) > 0
+
+
+def getAvailableJVMLibraries():
+    """
+    Returns a list of available JNI wrapper libraries
+
+    :rtype: list
+    """
+    return _jvmLibraries
+
+
+def getJVMClasspath():
+    """
+    Returns the current JVM classpath
+    :rtype: list
+    """
+    return _jvmClasspath
+
+
+def addJVMClasspath(*paths):
+    """
+    Add the given list of paths to the JVM classpath.
+
+    :type paths: list
+    """
+    _jvmClasspath.extend(paths)
+
+
+def getJVMOptions():
+    """
+    Returns the current JVM options
+    :rtype: list
+    """
+    return _jvmOptions
+
+
+def addJVMOptions(*opts):
+    """
+    Add the given list of options to the JVM options.
+    :type opts: list
+    """
+    _jvmOptions.extend(opts)
+
+
+def getJavaVM(jnilib=JVMJNILib.JNIUS):
+    """
+    Returns a reference to a JavaVM instance based on the specified library.
+
+    :type jnilib: JVMJNILib
+    :rtype: JavaVM
+    """
+    try:
+        if jnilib == JVMJNILib.JNIUS:
+            vm = JniusJavaVM()
+        elif jnilib == JVMJNILib.JPYPE:
+            vm = JPypeJavaVM()
+        else:
+            vm = JavaVM()
+
+        if not vm.isRunning():
+            vm.addClasspath(*getJVMClasspath())
+            vm.addOptions(*getJVMOptions())
+
+        return vm
+    except NameError:
+        raise JVMError('No such JNI library \'{0}\''.format(jnilib))
+
+
+def findJavaHome():
+    """
+    Locate and return the path to a valid JRE installation,
+    or None if no such path can be found.
+
+    :rtype: str
+    """
+    # LOOK FOR BUNDLED JRE FIRST
+    if os.path.isdir(expandPath('@resources/java/')):
+        return expandPath('@resources/java/')
+    # TODO: BETTER ATTEMPT TO LOCATE JRE HOME
+    return os.getenv('JAVA_HOME')
+
+
+class JavaVM(object):
+    """
+    Abstract class representing the interface with the Java Virtual Machine.
+    """
+    _instance = None
+
+    def __init__(self):
+        """
+        Creates a new JavaVM instance.
+        """
+        self.classpath = getattr(self, 'classpath', [])
+        self.options = getattr(self, 'options', [])
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = object.__new__(cls)
+        return cls._instance
+
+    #############################################
+    #   INTERFACE
+    #################################
+
+    def initialize(self):
+        """
+        Initializes the JVM instance.
+        """
+        pass
+
+    def getJavaClass(self, cname: str) -> object:
+        """
+        Returns a wrapper object representing the Java class identified by the canonical name `cname`.
+        Raises an error if called before initializing the JVM.
+
+        :type cname: str
+        :rtype: object
+        """
+        pass
+
+    def cast(self, destclass: object, obj: object) -> object:
+        """
+        Returns the given Java object `obj` casted to class `destclass`.
+
+        :type destclass: object
+        :type obj: object
+        :rtype: object
+        """
+        pass
+
+    def isRunning(self):
+        """
+        Returns `True` if a JVM instance is already running.
+
+        :rtype: bool
+        """
+        pass
+
+    def addOptions(self, *opts):
+        """
+        Append options to the list of JVM start-up options
+
+        :type opts: list
+        """
+        self.options.extend(opts)
+
+    def getOptions(self):
+        """
+        Returns the list of options used by the JVM.
+
+        :rtype: list
+        """
+        return self.options
+
+    def addClasspath(self, *paths):
+        """
+        Appends items to the classpath for the JVM to use.
+        Replaces any existing classpath, overriding the CLASSPATH environment variable.
+
+        :type paths: list
+        """
+        self.classpath.extend(paths)
+
+    def setClasspath(self, *paths):
+        """
+        Sets the classpath for the JVM to use. Replaces any existing classpath,
+        overriding the CLASSPATH environment variable.
+
+        :type paths: list
+        """
+        self.classpath = list(paths)
+
+    def getClasspath(self):
+        """
+        Retrieves the classpath the JVM will use.
+
+        :rtype: list
+        """
+        return self.classpath
+
+    def isThreadAttachedToJVM(self):
+        """
+        Returns True if the current python thread is attached to the JVM thread, and False otherwise.
+
+        :rtype: bool
+        """
+        pass
+
+    def attachThreadToJVM(self):
+        """
+        Attaches the current thread to the one running the JVM.
+
+        Each time you create a native Python thread that uses the Java API
+        you need to call this method explicitly before executing any call
+        to the Java library.
+        """
+        pass
+
+    def detachThreadFromJVM(self):
+        """
+        Detaches the current thread from the one running the JVM.
+
+        Each time you create a native Python thread that uses the Java API
+        you need to call this method explicitly before the thread terminates.
+        """
+        pass
+
+    def getImplementation(self):
+        """
+        Returns a reference to the library implementing this API.
+        """
+        pass
+
+    #############################################
+    #   CONTEXT MANAGER
+    #################################
+
+    def __enter__(self):
+        if not self.isRunning():
+            self.initialize()
+        self.attachThreadToJVM()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.isRunning():
+            self.detachThreadFromJVM()
+
+
+try:
+    # noinspection PyUnresolvedReferences
+    import jnius_config
+
+    if hasattr(sys, 'frozen'):
+        def get_classpath():
+            """
+            Retrieves the classpath the JVM will use.
+
+            This function is intended to patch the default jnius_config (>1.1.0) implementation
+            that makes use of pkg_resources.resource_filename to retrieve the path
+            for additional Java classes inside the jnius module, which cannot be
+            used when the application is frozen.
+            """
+            # add a path to java classes packaged with jnius
+            return_classpath = [expandPath('@resources/lib/')]
+
+            if jnius_config.classpath is not None:
+                return_classpath = jnius_config.classpath + return_classpath
+            elif 'CLASSPATH' in os.environ:
+                return_classpath = os.environ['CLASSPATH'].split(jnius_config.split_char) + return_classpath
+            else:
+                return_classpath = [os.path.realpath('.')] + return_classpath
+            return return_classpath
+
+        # PATCH jnius_config IMPLEMENTATION
+        jnius_config.get_classpath = get_classpath
+
+
+    class JniusJavaVM(JavaVM):
+        """
+        Implementation of a JavaVM using pyjnius as the backend wrapper.
+        """
+        _instance = None
+
+        def __init__(self):
+            super().__init__()
+            self.jnius = getattr(self, 'jnius', None)
+            self.initialized = getattr(self, 'initialized', False)
+
+            # If some other module has imported jnius prior
+            # to the object creation, then the vm is already initialized
+            # i.e. classpath and options cannot be set anymore
+            if not self.initialized and jnius_config.vm_running:
+                import jnius
+                self.initialized = True
+                self.jnius = jnius
+
+        @classmethod
+        def __new__(cls, *args, **kwargs):
+            if not cls._instance:
+                cls._instance = object.__new__(cls)
+            return cls._instance
+
+        #############################################
+        #   INTERFACE
+        #################################
+
+        def initialize(self):
+            """
+            Initializes the JVM instance.
+            """
+            if self.initialized:
+                return
+
+            try:
+                # IMPORT JNIUS TO TRIGGER CREATION OF JNIENV
+                import jnius
+                self.jnius = jnius
+                self.initialized = True
+            except BaseException as e:
+                raise JVMError('Error initializing JVM instance: {0}'.format(e))
+
+        def getJavaClass(self, cname: str) -> object:
+            """
+            Returns a wrapper object representing the Java class identified by the canonical name `cname`.
+            Raises an error if called before initializing the JVM.
+
+            :type cname: str
+            :rtype: object
+            """
+            if not self.isRunning():
+                raise JVMError('JVM has not been initialized yet')
+            try:
+                return self.jnius.autoclass(cname)
+            except Exception as e:
+                raise JVMClassNotFoundError('No such class {0}: {1}'.format(cname, e))
+
+        def cast(self, destclass: object, obj: object) -> object:
+            """
+            Returns the given Java object `obj` casted to class `destclass`.
+
+            :type destclass: object
+            :type obj: object
+            :rtype: object
+            """
+            return self.jnius.cast(destclass, obj)
+
+        def addOptions(self, *opts):
+            """
+            Append options to the list of JVM start-up options
+
+            :type opts: list
+            """
+            super().addOptions(*opts)
+            try:
+                jnius_config.add_options(*opts)
+            except ValueError as e:
+                raise JVMError(e)
+
+        def getOptions(self):
+            """
+            Returns the list of options used by the JVM.
+
+            :rtype: list
+            """
+            return jnius_config.get_options()
+
+        def addClasspath(self, *paths):
+            """
+            Appends items to the classpath for the JVM to use.
+            Replaces any existing classpath, overriding the CLASSPATH environment variable.
+
+            :type paths: list
+            """
+            super().addClasspath(*paths)
+            try:
+                for path in paths:
+                    jnius_config.add_classpath(path)
+            except ValueError as e:
+                raise JVMError(e)
+
+        def setClasspath(self, *paths):
+            """
+            Sets the classpath for the JVM to use. Replaces any existing classpath,
+            overriding the CLASSPATH environment variable.
+
+            :type paths: list
+            """
+            super().setClasspath(*paths)
+            try:
+                jnius_config.set_classpath(*paths)
+            except ValueError as e:
+                raise JVMError(e)
+
+        def getClasspath(self):
+            """
+            Retrieves the classpath the JVM will use.
+
+            :rtype: list
+            """
+            return jnius_config.get_classpath()
+
+        def isRunning(self):
+            """
+            Returns `True` if a JVM instance is already running.
+
+            :rtype: bool
+            """
+            return jnius_config.vm_running
+
+        def isThreadAttachedToJVM(self):
+            """
+            Returns True if the current python thread is attached to the JVM thread, and False otherwise.
+
+            :rtype: bool
+            """
+            return self.isRunning()
+
+        def detachThreadFromJVM(self):
+            """
+            Detaches the current thread from the one running the JVM.
+
+            Each time you create a native Python thread that uses the Java API
+            you need to call this method explicitly before the thread terminates.
+            """
+            if self.isRunning():
+                self.jnius.detach()
+
+        def getImplementation(self):
+            """
+            Returns a reference to the library implementing this API.
+            """
+            return self.jnius
+
+    # ADD JNIUS TO THE AVAILABLE WRAPPERS
+    _jvmLibraries.append(JVMJNILib.JNIUS)
+
+except ImportError:
+    pass
+
+try:
+    # noinspection PyUnresolvedReferences
+    import jpype
+
+    class JPypeJavaVM(JavaVM):
+        """
+        Implementation of a JavaVM that uses jpype as the backend wrapper.
+        """
+        _instance = None
+
+        def __init__(self):
+            super().__init__()
+            self.jpype = getattr(self, 'jpype', jpype)
+            self.initialized = getattr(self, 'initialized', False)
+
+        def __new__(cls, *args, **kwargs):
+            if not cls._instance:
+                cls._instance = object.__new__(cls)
+            return cls._instance
+
+        #############################################
+        #   INTERFACE
+        #################################
+
+        def initialize(self):
+            """
+            Initializes the JVM instance.
+            """
+            if self.initialized:
+                return
+            try:
+                sep = ';' if _WIN32 else ':'
+                classpath = sep.join([p for p in self.classpath])
+                jpype.startJVM(jpype.getDefaultJVMPath(), '-Djava.class.path={0}'.format(classpath), *self.options)
+                self.jpype = jpype
+                self.initialized = True
+            except RuntimeError as e:
+                raise JVMError('Error initializing JVM: {0}'.format(e))
+
+        def isRunning(self):
+            """
+            Returns `True` if a JVM instance is already running.
+
+            :rtype: bool
+            """
+            return self.initialized and self.jpype.isJVMStarted()
+
+        def getJavaClass(self, cname: str):
+            """
+            Returns a wrapper object representing the Java class identified by the canonical name `cname`.
+            Raises an error if the JVM if called before initializing the JVM.
+
+            :type cname: str
+            :rtype: object
+            """
+            if not self.initialized:
+                raise JVMError('JVM has not been initialized yet')
+            try:
+                splits = cname.split('.')
+                ret = self.jpype.JPackage(splits[0])
+                for pkg in splits[1:]:
+                    ret = getattr(ret, pkg)
+                return ret
+            except Exception as e:
+                raise JVMClassNotFoundError('No such class {0}: {1}'.format(cname, e))
+
+        def cast(self, destclass, obj):
+            """
+            Returns the given Java object `obj` casted to class `destclass`.
+
+            :type destclass: object
+            :type obj: object
+            :rtype: object
+            """
+            return obj
+
+        def isThreadAttachedToJVM(self):
+            """
+            Returns True if the current python thread is attached to the JVM thread, and False otherwise.
+
+            :rtype: bool
+            """
+            return self.isRunning() and self.jpype.isThreadAttachedToJVM()
+
+        def attachThreadToJVM(self):
+            """
+            Attaches the current thread to the one running the JVM.
+
+            Each time you create a native Python thread that uses the Java API
+            you need to call this method explicitly before executing any call
+            to the Java library.
+            """
+            self.jpype.attachThreadToJVM()
+
+        def detachThreadFromJVM(self):
+            """
+            Detaches the current thread from the one running the JVM.
+
+            Each time you create a native Python thread that uses the Java API
+            you need to call this method explicitly before the thread terminates.
+            """
+            if self.jpype.isThreadAttachedToJVM():
+                self.jpype.detachThreadFromJVM()
+                pass
+
+        def getImplementation(self):
+            """
+            Returns a reference to the library implementing this API.
+            """
+            return self.jpype
+
+    # ADD JPYPE TO THE AVAILABLE WRAPPERS
+    _jvmLibraries.append(JVMJNILib.JPYPE)
+
+except ImportError:
+    pass
+
+
+class JVMError(RuntimeError):
+    """
+    Raised whenever there is an error with the JVM instance.
+    """
+    pass
+
+
+class JVMClassNotFoundError(JVMError):
+    """
+    Raised whenever there a requested Java class is not found in the classpath.
+    """
+    pass

--- a/eddy/core/project.py
+++ b/eddy/core/project.py
@@ -32,7 +32,9 @@
 #                                                                        #
 ##########################################################################
 
-from PyQt5 import QtCore,QtGui,QtWidgets
+from PyQt5 import QtCore
+from PyQt5 import QtGui
+from PyQt5 import QtWidgets
 
 from eddy.core.datatypes.owl import OWLStandardIRIPrefixPairsDict
 from eddy.core.datatypes.graphol import Item, Identity
@@ -41,16 +43,16 @@ from eddy.core.commands.nodes import CommandNodeSetMeta
 from eddy.core.commands.nodes_2 import CommandProjetSetIRIPrefixesNodesDict
 from eddy.core.commands.labels import GenerateNewLabel, CommandLabelChange
 from eddy.core.commands.project import CommandProjectDisconnectSpecificSignals, CommandProjectConnectSpecificSignals
-#from eddy.core.functions.owl import OWLText
+from eddy.core.functions.owl import OWLText
 from eddy.core.functions.path import expandPath
 from eddy.core.functions.signals import connect, disconnect
+from eddy.core.jvm import getJavaVM
 from eddy.core.output import getLogger
 from eddy.core.items.common import AbstractItem
 from eddy.core.items.nodes.common.base import AbstractNode
 from eddy.ui.DiagramsSelectionDialog import DiagramsSelectionDialog
 from eddy.ui.resolvers import PredicateBooleanConflictResolver
 from eddy.ui.resolvers import PredicateDocumentationConflictResolver
-from jnius import autoclass, cast, detach
 
 from rfc3987 import parse
 
@@ -1365,30 +1367,6 @@ class Project(QtCore.QObject):
         disconnect(self.sgnItemAdded, self.reset_changes_made_after_reasoning_task)
         disconnect(self.sgnItemRemoved, self.reset_changes_made_after_reasoning_task)
 
-    #not used
-    def check_if_reasoner_was_active(self):
-
-        A = len(self.unsatisfiable_classes) > 0
-        B = len(self.unsatisfiable_attributes)  > 0
-        C = len(self.unsatisfiable_roles)  > 0
-
-        D = self.inconsistent_ontology is not None
-
-        if (A is True) and (B is True) and (C is True) and (D is True):
-
-            return 'inactive'
-
-        else:
-
-            if (D is True) and ((A is False) or (B is False) or (C is False)):
-
-                return 'was_unsatisfiable'
-
-            elif (D is False) :
-
-                return 'was_inconsistent'
-
-
     def colour_items_in_case_of_unsatisfiability_or_inconsistent_ontology(self):
 
         for node_or_edge in self.nodes_or_edges_of_explanations_to_display_in_widget:
@@ -1444,9 +1422,7 @@ class Project(QtCore.QObject):
         abs_nodes = self.nodes()
 
         for diag, val_in_diag in self.converted_nodes.items():
-            #print('diag, val_in_diag',diag, val_in_diag)
             for nd in val_in_diag:
-
                 abs_nd = None
                 for i in abs_nodes:
                     #if i.id == nd:
@@ -1458,13 +1434,8 @@ class Project(QtCore.QObject):
                     ((str(diag + '-' + nd) == node.id_with_diag) or ((abs_nd is not None) and (abs_nd.text() == node.text()))):
                     # ((nd==node.id) or ((abs_nd is not None) and (abs_nd.text()==node.text()))):
                     if str(type(val_in_diag[nd])) == '<class \'list\'>':
-
                         return_list = []
                         for ele in val_in_diag[nd]:
-                            java_class = str(val_in_diag[nd])[2:str(val_in_diag[nd]).index(' ')]
-                            cast(autoclass(java_class), ele)
-                            detach()
-
                             return_list.append(ele.toString())
 
                         return return_list
@@ -1474,14 +1445,9 @@ class Project(QtCore.QObject):
 
                         while listIter.hasNext():
                             chainList.append(listIter.next())
-                        detach()
 
                         return chainList
                     else:
-                        java_class = str(val_in_diag[nd])[1:str(val_in_diag[nd]).index(' ')]
-                        cast(autoclass(java_class), val_in_diag[nd])
-                        detach()
-
                         return val_in_diag[nd].toString()
 
         return None

--- a/eddy/plugins/Explanation-Explorerv0.1/Explanation_explorer.py
+++ b/eddy/plugins/Explanation-Explorerv0.1/Explanation_explorer.py
@@ -33,25 +33,23 @@
 ##########################################################################
 
 
+import sys
+
 from PyQt5 import QtCore
 from PyQt5 import QtGui
 from PyQt5 import QtWidgets
 
-from eddy.core.output import getLogger
 from eddy.core.datatypes.graphol import Item, Identity
 from eddy.core.datatypes.qt import Font
 from eddy.core.datatypes.system import File
 from eddy.core.functions.misc import first, rstrip
 from eddy.core.functions.signals import connect, disconnect
-from eddy.core.plugin import AbstractPlugin
 from eddy.core.items.common import AbstractItem
-
+from eddy.core.jvm import getJavaVM
+from eddy.core.output import getLogger
+from eddy.core.plugin import AbstractPlugin
 from eddy.ui.dock import DockWidget
 from eddy.ui.fields import StringField
-
-import inspect
-import sys
-from jnius import autoclass, cast, detach
 
 
 LOGGER = getLogger()
@@ -82,6 +80,11 @@ class ExplanationExplorerPlugin(AbstractPlugin):
         connect(self.sgnFakeAxiomAdded, widget.doAddAxiom)
         connect(self.sgnFakeItemAdded, widget.doAddNodeOREdge)
 
+        self.vm = getJavaVM()
+        if not self.vm.isRunning():
+            self.vm.initialize()
+        self.vm.attachThreadToJVM()
+
         if len(self.project.explanations_for_inconsistent_ontology) >0 and len(self.project.explanations_for_unsatisfiable_classes) >0:
             LOGGER.error('Error, len(self.project.explanations_for_inconsistent_ontology) >0 and len(self.project.explanations_for_unsatisfiable_classes) >0:')
             sys.exit(0)
@@ -99,10 +102,6 @@ class ExplanationExplorerPlugin(AbstractPlugin):
             elif 'RoleNode' in self.project.uc_as_input_for_explanation_explorer:
                 unsatisfiable_entities = self.project.unsatisfiable_roles
                 explanations_unsatisfiable_entity = self.project.explanations_for_unsatisfiable_roles
-
-            #print('self.project.uc_as_input_for_explanation_explorer',self.project.uc_as_input_for_explanation_explorer)
-
-            #print('self.project.uc_as_input_for_explanation_explorer',self.project.uc_as_input_for_explanation_explorer)
 
             inp_node = None
 
@@ -140,8 +139,6 @@ class ExplanationExplorerPlugin(AbstractPlugin):
                 if len(q_exp_items) !=1:
                     LOGGER.error('multiple or 0 QStandardItems found for q_exp_item')
                     sys.exit(0)
-
-                cast(autoclass('org.semanticweb.owlapi.model.OWLAxiom'), axiom_e)
 
                 self.sgnFakeAxiomAdded.emit(q_exp_items[0], axiom_e.toString())
 
@@ -228,6 +225,7 @@ class ExplanationExplorerPlugin(AbstractPlugin):
         # INSTALL DOCKING AREA WIDGET
         self.debug('Installing docking area widget')
         self.session.addDockWidget(QtCore.Qt.RightDockWidgetArea ,self.widget('Explanation_explorer_dock'))
+
 
 class ExplanationExplorerWidget(QtWidgets.QWidget):
     """

--- a/eddy/plugins/Explanation-Explorerv0.1/Explanation_explorer.py
+++ b/eddy/plugins/Explanation-Explorerv0.1/Explanation_explorer.py
@@ -87,7 +87,6 @@ class ExplanationExplorerPlugin(AbstractPlugin):
 
         if len(self.project.explanations_for_inconsistent_ontology) >0 and len(self.project.explanations_for_unsatisfiable_classes) >0:
             LOGGER.error('Error, len(self.project.explanations_for_inconsistent_ontology) >0 and len(self.project.explanations_for_unsatisfiable_classes) >0:')
-            sys.exit(0)
 
         #choose the explanation
         if len(self.project.explanations_for_inconsistent_ontology) > 0:
@@ -138,7 +137,6 @@ class ExplanationExplorerPlugin(AbstractPlugin):
 
                 if len(q_exp_items) !=1:
                     LOGGER.error('multiple or 0 QStandardItems found for q_exp_item')
-                    sys.exit(0)
 
                 self.sgnFakeAxiomAdded.emit(q_exp_items[0], axiom_e.toString())
 

--- a/eddy/ui/ontology_consistency_check.py
+++ b/eddy/ui/ontology_consistency_check.py
@@ -392,8 +392,7 @@ class OntologyConsistencyCheckWorker(AbstractWorker):
                 exists_for_some_objects = self.OWLFunctionalSyntaxFactory.ObjectSomeValuesFrom(unsatisfiable_entity, self.OWLFunctionalSyntaxFactory.OWLThing());
                 axiom_err = self.manager.getOWLDataFactory().getOWLSubClassOfAxiom(exists_for_some_objects, self.OWLFunctionalSyntaxFactory.OWLNothing());
             else:
-                LOGGER.error('invalid unsatisfiable entity')
-                sys.exit(0)
+                raise RuntimeError('Invalid unsatisfiable entity {0}'.format(java_class))
 
             axiom_err_sc = axiom_err.getSubClass()
             explanations_raw = self.generator_unsatisfiable_entities.getExplanations(axiom_err_sc)
@@ -415,31 +414,14 @@ class OntologyConsistencyCheckWorker(AbstractWorker):
         if java_class == self.OWLClass:
             self.project.unsatisfiable_classes = unsatisfiable_entities_string
             self.project.explanations_for_unsatisfiable_classes = explanations_for_all_unsatisfiable_entities
-
-            if len(self.project.unsatisfiable_classes) != len(self.project.explanations_for_unsatisfiable_classes):
-                LOGGER.critical('len(self.project.unsatisfiable_classes) != len(explanations_for_all_unsatisfiable_classes)')
-                sys.exit(0)
-        
         elif java_class == self.OWLDataProperty:
             self.project.unsatisfiable_attributes = unsatisfiable_entities_string
             self.project.explanations_for_unsatisfiable_attributes = explanations_for_all_unsatisfiable_entities
-
-            if len(self.project.unsatisfiable_attributes) != len(self.project.explanations_for_unsatisfiable_attributes):
-                LOGGER.critical(
-                    'len(self.project.unsatisfiable_attributes) != len(explanations_for_all_unsatisfiable_attributes)')
-                sys.exit(0)
-        
         elif java_class == self.OWLObjectPropertyExpression:
             self.project.unsatisfiable_roles = unsatisfiable_entities_string
             self.project.explanations_for_unsatisfiable_roles = explanations_for_all_unsatisfiable_entities
-
-            if len(self.project.unsatisfiable_roles) != len(self.project.explanations_for_unsatisfiable_roles):
-                LOGGER.critical(
-                    'len(self.project.unsatisfiable_roles) != len(explanations_for_all_unsatisfiable_roles)')
-                sys.exit(0)
         else:
-            LOGGER.error('invalid unsatisfiable entity')
-            sys.exit(0)
+            raise RuntimeError('invalid unsatisfiable entity {0}'.format(java_class))
 
     def reason_over_ontology(self):
         self.status_bar.showMessage('Fetching ontology')
@@ -485,8 +467,7 @@ class OntologyConsistencyCheckWorker(AbstractWorker):
             if hermit.isConsistent() is True:
                 self.project.inconsistent_ontology = False
             else:
-                LOGGER.info('ontology is inconsistent however exception was not thrown')
-                sys.exit(0)
+                raise RuntimeError('ontology is inconsistent however exception was not thrown')
 
             factory = self.ReasonerFactory()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ cov-core==1.15.0
 coverage==4.5.1
 cryptography==2.3.1
 cx-Freeze==5.1.1
-Cython==0.26
+Cython==0.29.6
 github3.py==1.2.0
 idna==2.7
 jwcrypto==0.6.0
@@ -20,7 +20,7 @@ packaging==18.0
 pbr==5.1.1
 Pillow==5.3.0
 pycparser==2.19
-pyjnius==1.1.1
+pyjnius==1.2.0
 pyparsing==2.3.0
 PyQt5==5.10.1
 python-dateutil==2.7.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,4 +9,4 @@ verlib==0.1
 github3.py==1.2.0
 natsort==5.2.0
 requests==2.20.1
-pyjnius==1.1.1
+pyjnius==1.2.0

--- a/requirements/cython.txt
+++ b/requirements/cython.txt
@@ -1,15 +1,6 @@
-# Cython requirements
-# 
-# Stick with 0.26 as new versions cause issues with pyjnius<=1.1.1
 #
-# https://github.com/kivy/pyjnius/issues/300
+# Cython requirement
 #
-# As of Oct 22, 2018 pyjnius has updated to 1.1.3 effectively closing issue #300,
-# we cannot however update to 1.1.3 as it causes problems with cx_Freeze.
-# In particular, jnius_config relies on resource_filename from pkg_resources
-# to add Java classes from the jnius package to the classpath, and for this to work
-# in the bundled version of Eddy it is required for jnius_config to be left outside 
-# of the zip file, which is not currently possible in cx_Freeze 5.1.1 for single file modules.
 
 # From PyPi
-Cython==0.26
+Cython==0.29.6

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@
 import cx_Freeze
 import distutils
 import os
+import pkg_resources
 import platform
 import py_compile
 import re
@@ -900,6 +901,11 @@ include_files = [
     ('PACKAGING.md', 'PACKAGING.md'),
     ('README.md', 'README.md'),
 ]
+
+# INCLUDE JNIUS > 1.1.0 JAVA HELPERS
+jnius_src = os.path.realpath(pkg_resources.resource_filename('jnius_config', 'jnius/src'))
+if os.path.isdir(jnius_src):
+    include_files.append((jnius_src, 'resources/lib'))
 
 if LINUX:
     include_files.extend([

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -89,11 +89,11 @@ class ExportTestCase(EddyTestCase):
     #   OWL EXPORT
     #################################
 
-    @unittest.skip('Restore after enabling non-interactive selection of diagrams to export')
     def test_export_project_to_owl_without_normalization(self):
         # WHEN
         worker = OWLOntologyExporterWorker(self.project, '@tests/.tests/test_project_1.owl',
-           axioms={x for x in OWLAxiom}, normalize=False, syntax=OWLSyntax.Functional)
+                                           axioms={x for x in OWLAxiom}, normalize=False, syntax=OWLSyntax.Functional,
+                                           selected_diagrams=self.project.diagrams())
         worker.run()
         # THEN
         self.assertFileExists('@tests/.tests/test_project_1.owl')
@@ -129,8 +129,7 @@ class ExportTestCase(EddyTestCase):
         self.assertIn('Declaration(ObjectProperty(test:drives))', content)
         self.assertIn('Declaration(DataProperty(test:name))', content)
         self.assertIn('Declaration(Datatype(xsd:string))', content)
-        self.assertIn('Declaration(AnnotationProperty(<rdfs:comment>))', content)
-        self.assertIn('AnnotationAssertion(<rdfs:comment> test:Person "A human being"^^xsd:string)', content)
+        self.assertIn('AnnotationAssertion(rdfs:comment test:Person "A human being"^^xsd:string)', content)
         self.assertIn('SubClassOf(test:Person ObjectSomeValuesFrom(test:hasAncestor owl:Thing))', content)
         self.assertIn('SubClassOf(test:Father test:Male)', content)
         self.assertIn('SubClassOf(test:Mother test:Female)', content)
@@ -180,13 +179,13 @@ class ExportTestCase(EddyTestCase):
         self.assertAnyIn(['DisjointClasses(test:Less_than_50_cc test:Over_50_cc)',
                           'DisjointClasses(test:Over_50_cc test:Less_than_50_cc)'], content)
         # AND
-        self.assertLen(61, content)
+        self.assertLen(59, content)
 
-    @unittest.skip('Restore after enabling non-interactive selection of diagrams to export')
     def test_export_project_to_owl_with_normalization(self):
         # WHEN
         worker = OWLOntologyExporterWorker(self.project, '@tests/.tests/test_project_1.owl',
-           axioms={x for x in OWLAxiom}, normalize=True, syntax=OWLSyntax.Functional)
+                                           axioms={x for x in OWLAxiom}, normalize=True, syntax=OWLSyntax.Functional,
+                                           selected_diagrams=self.project.diagrams())
         worker.run()
         # THEN
         self.assertFileExists('@tests/.tests/test_project_1.owl')
@@ -222,8 +221,7 @@ class ExportTestCase(EddyTestCase):
         self.assertIn('Declaration(ObjectProperty(test:drives))', content)
         self.assertIn('Declaration(DataProperty(test:name))', content)
         self.assertIn('Declaration(Datatype(xsd:string))', content)
-        self.assertIn('Declaration(AnnotationProperty(<rdfs:comment>))', content)
-        self.assertIn('AnnotationAssertion(<rdfs:comment> test:Person "A human being"^^xsd:string)', content)
+        self.assertIn('AnnotationAssertion(rdfs:comment test:Person "A human being"^^xsd:string)', content)
         self.assertIn('SubClassOf(test:Person ObjectSomeValuesFrom(test:hasAncestor owl:Thing))', content)
         self.assertIn('SubClassOf(test:Father test:Male)', content)
         self.assertIn('SubClassOf(test:Mother test:Female)', content)
@@ -273,4 +271,4 @@ class ExportTestCase(EddyTestCase):
         self.assertAnyIn(['DisjointClasses(test:Less_than_50_cc test:Over_50_cc)',
                           'DisjointClasses(test:Over_50_cc test:Less_than_50_cc)'], content)
         # AND
-        self.assertLen(68, content)
+        self.assertLen(66, content)


### PR DESCRIPTION
This new API allows application modules to abstract from the specific JNI bridging libraries. Currently supported libraries are jnius and jpype.
Also, move the application entry point inside the application package (in preparation for a migration to setuptools) and gracefully deal with the situation where a JRE is not found on the system.

