### PR TITLE
Move from create-dmg to dmgbuild for .dmg creation on macOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "support/createdmg"]
-	path = support/createdmg
-    url = ../../obdasystems/create-dmg.git

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,13 +4,15 @@
 #
 #    pip-compile --output-file=requirements-dev.txt requirements/dev.in
 #
-altgraph==0.17            # via pyinstaller
+altgraph==0.17            # via macholib, pyinstaller
 appdirs==1.4.4            # via virtualenv
 attrs==20.3.0             # via pytest
 click==7.1.2              # via pip-tools
 coverage==5.3             # via pytest-cov
 cython==0.29.21           # via -r requirements/cython.in
 distlib==0.3.1            # via virtualenv
+dmgbuild==1.4.2 ; sys_platform == "darwin"  # via -r requirements/packaging.in
+ds-store==1.3.0           # via dmgbuild
 easyprocess==0.3          # via pyvirtualdisplay
 filelock==3.0.12          # via tox, virtualenv
 flake8==3.8.4             # via -r requirements/dev.in
@@ -18,7 +20,8 @@ graphviz==0.15            # via objgraph
 importlib-metadata==2.1.1  # via flake8, pluggy, pytest, tox, virtualenv
 iniconfig==1.1.1          # via pytest
 jpype1==1.2.0             # via -r requirements/base.in
-macholib ; sys_platform == 'darwin'  # via pyinstaller
+mac-alias==2.2.0          # via dmgbuild, ds-store
+macholib==1.14 ; sys_platform == "darwin"  # via pyinstaller
 mccabe==0.6.1             # via flake8
 objgraph==3.5.0           # via -r requirements/dev.in
 packaging==20.8           # via pytest, tox

--- a/requirements/packaging.in
+++ b/requirements/packaging.in
@@ -4,6 +4,7 @@
 -r base.in
 
 # From PyPi
+dmgbuild==1.4.2; sys_platform == 'darwin'
+Pillow==8.0.1
 PyInstaller==4.1
 PyYAML==5.3.1; sys_platform == 'win32'
-Pillow==8.0.1

--- a/support/dmgbuild/settings.py
+++ b/support/dmgbuild/settings.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+#
+# dmgbuild settings file
+#
+# See https://dmgbuild.readthedocs.io/en/latest/settings.html for a list of available options.
+
+# The application name.
+appname = defines.get('appname')
+appdir = defines.get('appdir', '{}.app'.format(appname))
+
+# If defined, overrides the output filename specified on the command line.
+# The command line value is the default value.
+#filename =
+
+# If defined, overrides the volume name specified on the command line,
+# which is the default value.
+#volume_name =
+
+# Specifies the format code for the final output disk image.
+# Must be one of the types supported by hdiutil on the build system.
+# See https://dmgbuild.readthedocs.io/en/latest/settings.html#format
+# for a list of supported formats.
+format = defines.get('format', 'UDBZ')
+
+# If defined, specifies the size of the filesystem within the image.
+# If this is not defined, dmgbuild will attempt to determine a reasonable
+# size for the image.
+size = defines.get('size', None)
+
+# A list of files (or folders) to copy into the image.
+# Each of these is copied to the root of the image; folders are copied recursively.
+files = defines.get('files')
+
+# A dictionary specifying symbolic links to create in the image.
+symlinks = defines.get('symlinks', {'Applications': '/Applications'})
+
+# Specifies the path of an icon file to copy to the volume.
+# Either specify this, or as an alternative use the badge_icon setting.
+icon = defines.get('icon', None)
+
+# As an alternative to the above, if you set badge_icon to the path
+# of an icon file or image, it will be used to badge the system’s standard
+# external disk icon.
+badge_icon = defines.get('badge_icon', None)
+
+# If arrange_by is not set, a dictionary mapping the names of items
+# in the root of the volume to an (x, y) tuple specifying their location in points.
+icon_locations = defines.get('icon_locations', {
+    appdir: (60, 50),
+    'Applications': (60, 130),
+})
+
+# A string containing the window background color,
+# or the path to an image.
+background = defines.get('background', None)
+
+# The position of the window in ((x, y), (w, h)) format, with y coordinates
+# running from bottom to top. Values for x and y are clamped to fit
+# within the display bounds.
+window_rect = defines.get('window_rect', None)
+
+# Specifies the point size of the label text.
+# Default is 16pt.
+text_size = defines.get('text_size', 12)
+
+# Specifies the size of icon to use.
+# Default is 128pt.
+icon_size = defines.get('icon_size', 48)
+
+# dmgbuild can attach license text to the disk image;
+# this will be displayed automatically when the user
+# tries to open the disk image.
+license = {
+    'default-language': 'en_US',
+    'licenses': {
+        'en_US': defines.get('license_file', None)
+    }
+}


### PR DESCRIPTION
Starting from macOS 10.14, the create-dmg script requires user intervention when creating disk images due to the new security restrictions on macOS and their use of applescript to generate the .DS_Store file inside the disk image. This makes it impossible without workarounds to run it in a ci environment such as that of travis.

This pull request changes the .dmg creation step from using create-dmg to using dmgbuild, a python module that still relies on hciutil to build the disk image, but uses the ds_store python module to create the directory service store file without resorting to Finder, and thus circumventing the user permission request and allowing the use of macOS 10.14+ as the host for automated builds.

This also gets rid of the createdmg submodule as it is not needed anymore.