### PR TITLE
Introduce AppImage support for releases on GNU/Linux

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             python-version: 3.8
 
           - os: macos-10.15
@@ -34,6 +34,13 @@ jobs:
         run: |
           python -m pip install -U pip setuptools wheel
           python -m pip install -U -r requirements/in/dev.in
+
+      - name: Package application (AppImage)
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+          sudo chmod +x /usr/local/bin/appimagetool
+          python setup.py appimage --skip-tests
 
       - name: Package application (archive)
         if: ${{ startsWith(matrix.os, 'ubuntu') }}

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -24,10 +24,10 @@ or the latest JDK 11 from Oracle. Make sure the corresponding executables can be
 Make sure to set the `JAVA_HOME` environment variable to point to the location where the JDK is installed.
 
 #### Install a C compiler (optional)
-If you wish to build all dependencies from source distribution, you will need to install a C compiler.
+If you wish to build all dependencies from source, you will need to install a C compiler.
 
-Download and install [Visual C++ Build Tools v14.0](https://visualstudio.microsoft.com/visual-cpp-build-tools/).  Make sure to select
-`VC++ 2015.3 v14.00 toolset for Desktop` from the individual components tab in the installer menu.
+Download and install [Visual C++ Build Tools v14.0](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+Make sure to select `VC++ 2015.3 v14.00 toolset for Desktop` from the individual components tab in the installer menu.
 
 Once the installation is complete, you can easily access a command prompt that has
 everything configured to use the C compiler by using the Visual Studio 2015 Native
@@ -116,7 +116,7 @@ Install `pyenv` formula via Homebrew or by cloning the [repository](https://gith
     $ env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.7.7
 
 **NOTE**: Make sure to to add the `PYTHON_CONFIGURE_OPTS="--enable-framework"` to the `pyenv` command
-if you intend to use PyInstaller to built standalone packages.
+if you intend to use PyInstaller to build standalone releases.
 
 Install a JDK 1.8 or later. We recommend installing either the latest OpenJDK 11
 or OpenJDK 1.8 from [AdoptOpenJDK](https://adoptopenjdk.net) using Homebrew cask:
@@ -214,7 +214,7 @@ Compile and install a Python interpreter, e.g. 3.7.7:
     $ env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.7
 
 **NOTE**: Make sure to add the `PYTHON_CONFIGURE_OPTS="--enable-shared""` environment variable
- to the `pyenv` command if you intend to use PyInstaller to create standalone distribution packages.
+ to the `pyenv` command if you intend to use PyInstaller to build standalone releases.
 
 Choose a location for the virtualenv and create it. In what follows we show how to create it
 it a directory named `eddy-venv` inside the user's home folder:
@@ -267,9 +267,9 @@ To start Eddy, *cd* into the repository, and run the command:
 
     $ python run.py
 
-### Creating standalone distribution packages
+## Creating standalone releases
 
-Standalone packages are built for every Eddy release and published to [GitHub releases].
+Standalone releases are built for every Eddy release and published to [GitHub releases].
 They are the simplest form of distribution, that includes the application
 with all the required dependencies (including the Python interpreter and JVM).
 
@@ -279,24 +279,25 @@ Eddy is currently distributed in the following forms:
 * `Windows amd64` standalone package (.zip archive)
 * `Windows x86` standalone package (.zip archive)
 * `macOS x86_64` app bundle (distributed as .dmg)
-* `Linux x86_64` standalone package (.tar.gz archive) (**DEPRECATED**)
+* `Linux x86_64` AppImage (.AppImage file)
+* `Linux x86_64` standalone package (.tar.gz archive)
 * source package (.tar.gz or .zip archive)
 
-#### On Windows
+### On Windows
 To build a Windows binary installer, setup a development environment
 as described in the previous section, then run the following command
 from the root of the repository:
 
     $ python setup.py innosetup
 
-To build a Windows standalone (.zip) distribution, run the command:
+To build a Windows standalone (.zip) release, run the command:
 
     $ python setup.py standalone
 
 Once the building process is completed you will find the built
 package(s) inside the *dist* directory.
 
-##### On macOS
+### On macOS
 To build a macOS disk image (.dmg) containing the app bundle,
 setup a development environment as described in the previous section,
 then run the following command from the root of the repository:
@@ -306,15 +307,16 @@ then run the following command from the root of the repository:
 Once the building process is completed you will find the built
 package(s) inside the *dist* directory.
 
-##### On GNU/Linux
-**DEPRECATED**: Starting from version 3.0, the preferred method of install
-for Linux is via a prebuilt Python wheel from [GitHub releases],
-or from the a source package.
-Standalone tarballs may still be provided for some time but they
-are not the recommended method of installing Eddy.
+### On GNU/Linux
 
-To build Linux distribution packages, setup a development environment
-as described in the previous section, then run the following command:
+To build a Linux AppImage (.AppImage) release, you will need to setup
+a development environment as described in the previous section,
+download the [appimagetool] executable, then run the following
+command from the root of the repository:
+
+    $ python setup.py appimage
+
+To build Linux standalone tarball (.tar.gz), run the following command:
 
     $ python setup.py standalone
 
@@ -324,3 +326,4 @@ package(s) inside the *dist* directory.
 
 [AdoptOpenJDK]: https://adoptopenjdk.net
 [GitHub releases]: https://github.com/obdasystems/eddy/releases
+[appimagetool]: https://appimage.github.io/appimagetool

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,53 +2,48 @@
 
 Eddy can be installed via one of the following methods:
 
-* Downloading a standalone package from [GitHub releases].
-* Using one of the prebuilt Python wheels or source package from [GitHub releases].
-* Installing the latest snapshot from the sources in this [GitHub repository].
+* Downloading a standalone release from [GitHub releases].
+* Installing from source using a release tarball or from the [GitHub repository].
 
-Standalone packages come with all the required dependencies already bundled.
-This is the simplest way to get up and running with Eddy if you're on Windows or macOS.
-However, if you prefer manually installing a prebuilt wheel or a source package,
-then you will need to have Python 3.5 or later, and Java 1.8.0 or later already
-installed on your system.
+Standalone releases come with all the required dependencies already bundled.
+This is the simplest way to get up and running with Eddy.
+However, if you prefer manually installing from source, then you will need to have
+Python 3.5 or later, and Java 1.8 or later already installed on your system.
 
 If you encounter issues with the installation, please report them using the [issue tracker].
 
-### Using a standalone package
+## Using a standalone release
 
-Using a standalone package is the simpler way to get Eddy up and running, as
+Using a standalone release is the simpler way to get Eddy up and running, as
 it comes with its own copy of the Python interpreter and Java Virtual Machine.
-Windows and macOS users will most likely want to choose this option.
-GNU/Linux users can also find standalone packages for older versions of Eddy,
-however, starting from version 3.0 we do not support this form of distribution
-for any Linux distro, and instead recommend to use the prebuilt Python wheels,
-or a source package.
 
-#### Windows
+### Windows
 
-Simply download and install the latest executable from [GitHub releases].
+Simply download and run the latest installer from [GitHub releases].
 You can choose between 32 and 64 bit versions, depending on your system.
+
 If you do not have administrator privileges on your machine, you can download
-a standalone package provided as a `.zip` archive, unpack it, and start Eddy
+the standalone version provided as a `.zip` archive, unpack it, and start Eddy
 by double-clicking the `Eddy` executable.
 
-#### macOS
+### macOS
 
 Download the latest prebuilt `.dmg` from [GitHub releases], open it, then
 drag the Eddy application over the `Applications` folder.
 
-#### GNU/Linux (deprecated)
+### GNU/Linux
 
-Simply download the tarball from [GitHub releases] and unpack it anywhere on your system.
+Download the latest AppImage from [GitHub releases].
+To start Eddy, make the AppImage executable (via `chmod a+x`) and run it.
+
+Alternatively, you can download the standalone version provided as a tarball
+from [GitHub releases] and unpack it anywhere on your system.
 You can start Eddy by running the `Eddy` executable.
 
-### Installing from a source package or prebuilt wheel
+## Installing from a source tarball
 
-In order to install Eddy from a source package or prebuilt wheel you will need to have
-Python 3.5 or later, and a Java Runtime Environment 1.8 or later already installed on
-your system. If you do not have administrator privileges on the machine, you can install
-Eddy in a virtual environment to keep it separate from the system installation of Python.
-As of version 3.0, this is the recommended method of installing Eddy on GNU/Linux.
+In order to install Eddy from a source tarball you will need to have Python 3.5 or later,
+and a Java Runtime Environment 1.8 or later already installed on your system.
 
 The following additional Python requirements are needed:
  * PyQt5 >= 5.8
@@ -61,7 +56,7 @@ The following additional Python requirements are needed:
  the virtual environment first.
  The recommended option is to install using a virtual environment.
 
-##### Installing using a virtual environment
+### Installing using a virtual environment
 
 1. Choose a location where to install the virtualenv and use the `venv` python module to create it:
  ```bash
@@ -79,17 +74,8 @@ or, on Windows:
  C:\> eddy-venv\Scripts\activate.bat
  ```
 
-2. Download a prebuilt wheel from [GitHub releases] and install Eddy:
+2. Download a source tarball from [GitHub releases] and install Eddy:
 
- ```bash
- $ pip install PyQt5 >= 5.8 # Only if not already provided by the system installation
- $ pip install Eddy-<version>-py3-none-any.whl
- ```
-e.g., for v1.2.0:
-```bash
- $ pip install Eddy-1.2.0-py3-none-any.whl
-```
-or, when using a source package:
  ```bash
  $ pip install PyQt5 >= 5.8 # Only if not already provided by the system installation
  $ pip install https://github.com/obdasystems/eddy/archive/<version>.tar.gz
@@ -99,10 +85,8 @@ e.g.:
  $ pip install https://github.com/obdasystems/eddy/archive/v1.2.0.tar.gz
 ```
 
-If you prefer to use a local copy of the JDK, simply download one and and unpack it
-inside the `eddy/resources/java` folder (you will have to create it).
-If you prefer to use the system-wide Java installation instead, you only need to set the
-`JAVA_HOME` environment variable for your user to point to the JDK installation directory.
+To use a specific JRE installation, simply point the `JAVA_HOME` environment variable
+to it before starting Eddy.
 
 To start Eddy, an `eddy` script will be available inside the virtualenv.
 Just type `eddy` in a terminal, or execute the *eddy* module
@@ -117,67 +101,11 @@ or simply
 
 To uninstall Eddy, just delete the virtualenv folder.
 
-#### Installing as system Python module (NOT RECOMMENDED)
+### Installing the latest snapshot from the repository
 
-If you want to use the system Python installation on Linux, it is recommended to use your
-distribution package manager to install the additional dependencies as installing
-them from PyPI will most-likely cause dependency issues with existing applications:
+You can install Eddy directly by checking out the sources from the [GitHub repository].
+You will need to have git installed on your system.
 
-###### On Debian, Ubuntu, and derivatives
-```bash
- $ sudo apt-get install python3-pyqt5 python3-jpype python3-rfc3987
-```
-
-###### On Fedora / CentOS 8 / RHEL 8
-```bash
- $ sudo dnf install python3-qt5 python3-jpype python3-rfc3987
-```
-
-###### On ArchLinux / Manjaro
-```bash
- $ sudo pacman -S python-pyqt5 python-rfc3987
- $ sudo yaourt -S python-jpype # From AUR
-```
-
-Download a prebuilt wheel from [GitHub releases] and install Eddy, you will need
-administrator privileges:
-
- ```bash
- $ sudo pip install Eddy-<version>-py3-none-any.whl
- ```
-e.g., for v1.2.0:
-```bash
- $ sudo pip install Eddy-1.2.0-py3-none-any.whl
-```
-or, when using a source package:
- ```bash
- $ sudo pip install https://github.com/obdasystems/eddy/archive/<version>.tar.gz
- ```
-e.g.:
-```bash
- $ sudo pip install https://github.com/obdasystems/eddy/archive/v1.2.0.tar.gz
-```
-
-Once the installation is completed, you will be able to start Eddy by running
-the `eddy` command in a terminal, or by executing the `eddy` python module:
-```bash
- $ python -m eddy
-```
-or, simply:
-```bash
- $ eddy
-```
-
-To uninstall Eddy, simply use `pip` like any other python package:
-```bash
- $ sudo pip uninstall eddy
-```
-
-#### Installing the latest snapshot from the repository
-
-You can install Eddy directly by checking out the sources from the [GitHub repository]
-using Git. Just install the additional dependencies as described above,
-then install Eddy using the repository URL:
 ```bash
  $ pip install git+https://github.com/obdasystems/eddy.git@master
 ```

--- a/requirements/in/packaging.in
+++ b/requirements/in/packaging.in
@@ -4,6 +4,7 @@
 -r base.in
 
 # From PyPi
+appimage-builder==0.8.7; sys_platform == 'linux'
 dmgbuild==1.4.2; sys_platform == 'darwin'
 Pillow==8.1.1
 PyInstaller==4.2

--- a/requirements/out/requirements-py36-linux.txt
+++ b/requirements/out/requirements-py36-linux.txt
@@ -2,18 +2,32 @@ altgraph==0.17
     # via pyinstaller
 appdirs==1.4.4
     # via virtualenv
+appimage-builder==0.8.7 ; sys_platform == "linux"
+    # via -r requirements/in/packaging.in
 attrs==20.3.0
     # via pytest
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
 click==7.1.2
     # via pip-tools
+contextlib2==0.6.0.post1
+    # via schema
 coverage==5.5
     # via pytest-cov
 cython==0.29.22
     # via -r requirements/in/cython.in
+decorator==4.4.2
+    # via jsonpath-rw
 distlib==0.3.1
     # via virtualenv
+docker==4.4.4
+    # via appimage-builder
 easyprocess==0.3
     # via pyvirtualdisplay
+emrichen==0.2.3
+    # via appimage-builder
 filelock==3.0.12
     # via
     #   tox
@@ -22,6 +36,8 @@ flake8==3.8.4
     # via -r requirements/in/dev.in
 graphviz==0.16
     # via objgraph
+idna==2.10
+    # via requests
 importlib-metadata==2.1.1
     # via
     #   flake8
@@ -36,12 +52,15 @@ iniconfig==1.1.1
     # via pytest
 jpype1==1.2.1
     # via -r requirements/in/base.in
+jsonpath-rw==1.4.0
+    # via emrichen
 mccabe==0.6.1
     # via flake8
 objgraph==3.5.0
     # via -r requirements/in/dev.in
 packaging==20.9
     # via
+    #   appimage-builder
     #   pytest
     #   tox
 pillow==8.1.1
@@ -52,12 +71,18 @@ pluggy==0.13.1
     # via
     #   pytest
     #   tox
+ply==3.11
+    # via jsonpath-rw
+prompt-toolkit==3.0.18
+    # via questionary
 py-cpuinfo==7.0.0
     # via pytest-benchmark
 py==1.10.0
     # via
     #   pytest
     #   tox
+pyaml==20.4.0
+    # via emrichen
 pycodestyle==2.6.0
     # via flake8
 pyflakes==2.2.0
@@ -98,12 +123,28 @@ pytest==6.2.2
     #   pytest-xvfb
 pyvirtualdisplay==2.1
     # via pytest-xvfb
+pyyaml==5.4.1
+    # via
+    #   appimage-builder
+    #   emrichen
+    #   pyaml
+questionary==1.9.0
+    # via appimage-builder
+requests==2.25.1
+    # via
+    #   appimage-builder
+    #   docker
 rfc3987==1.3.8
     # via -r requirements/in/base.in
+schema==0.7.4
+    # via appimage-builder
 six==1.15.0
     # via
+    #   docker
+    #   jsonpath-rw
     #   tox
     #   virtualenv
+    #   websocket-client
 toml==0.10.2
     # via
     #   pytest
@@ -116,8 +157,14 @@ tox==3.22.0
     #   tox-factor
 typing-extensions==3.7.4.3
     # via jpype1
+urllib3==1.26.4
+    # via requests
 virtualenv==20.4.2
     # via tox
+wcwidth==0.2.5
+    # via prompt-toolkit
+websocket-client==0.58.0
+    # via docker
 zipp==3.4.0
     # via
     #   importlib-metadata

--- a/requirements/out/requirements-py37-linux.txt
+++ b/requirements/out/requirements-py37-linux.txt
@@ -2,18 +2,32 @@ altgraph==0.17
     # via pyinstaller
 appdirs==1.4.4
     # via virtualenv
+appimage-builder==0.8.7 ; sys_platform == "linux"
+    # via -r requirements/in/packaging.in
 attrs==20.3.0
     # via pytest
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
 click==7.1.2
     # via pip-tools
+contextlib2==0.6.0.post1
+    # via schema
 coverage==5.5
     # via pytest-cov
 cython==0.29.22
     # via -r requirements/in/cython.in
+decorator==4.4.2
+    # via jsonpath-rw
 distlib==0.3.1
     # via virtualenv
+docker==4.4.4
+    # via appimage-builder
 easyprocess==0.3
     # via pyvirtualdisplay
+emrichen==0.2.3
+    # via appimage-builder
 filelock==3.0.12
     # via
     #   tox
@@ -22,6 +36,8 @@ flake8==3.8.4
     # via -r requirements/in/dev.in
 graphviz==0.16
     # via objgraph
+idna==2.10
+    # via requests
 importlib-metadata==2.1.1
     # via
     #   flake8
@@ -34,12 +50,15 @@ iniconfig==1.1.1
     # via pytest
 jpype1==1.2.1
     # via -r requirements/in/base.in
+jsonpath-rw==1.4.0
+    # via emrichen
 mccabe==0.6.1
     # via flake8
 objgraph==3.5.0
     # via -r requirements/in/dev.in
 packaging==20.9
     # via
+    #   appimage-builder
     #   pytest
     #   tox
 pillow==8.1.1
@@ -50,12 +69,18 @@ pluggy==0.13.1
     # via
     #   pytest
     #   tox
+ply==3.11
+    # via jsonpath-rw
+prompt-toolkit==3.0.18
+    # via questionary
 py-cpuinfo==7.0.0
     # via pytest-benchmark
 py==1.10.0
     # via
     #   pytest
     #   tox
+pyaml==20.4.0
+    # via emrichen
 pycodestyle==2.6.0
     # via flake8
 pyflakes==2.2.0
@@ -96,12 +121,28 @@ pytest==6.2.2
     #   pytest-xvfb
 pyvirtualdisplay==2.1
     # via pytest-xvfb
+pyyaml==5.4.1
+    # via
+    #   appimage-builder
+    #   emrichen
+    #   pyaml
+questionary==1.9.0
+    # via appimage-builder
+requests==2.25.1
+    # via
+    #   appimage-builder
+    #   docker
 rfc3987==1.3.8
     # via -r requirements/in/base.in
+schema==0.7.4
+    # via appimage-builder
 six==1.15.0
     # via
+    #   docker
+    #   jsonpath-rw
     #   tox
     #   virtualenv
+    #   websocket-client
 toml==0.10.2
     # via
     #   pytest
@@ -114,8 +155,14 @@ tox==3.22.0
     #   tox-factor
 typing-extensions==3.7.4.3
     # via jpype1
+urllib3==1.26.4
+    # via requests
 virtualenv==20.4.2
     # via tox
+wcwidth==0.2.5
+    # via prompt-toolkit
+websocket-client==0.58.0
+    # via docker
 zipp==3.4.0
     # via importlib-metadata
 

--- a/requirements/out/requirements-py38-linux.txt
+++ b/requirements/out/requirements-py38-linux.txt
@@ -2,18 +2,32 @@ altgraph==0.17
     # via pyinstaller
 appdirs==1.4.4
     # via virtualenv
+appimage-builder==0.8.7 ; sys_platform == "linux"
+    # via -r requirements/in/packaging.in
 attrs==20.3.0
     # via pytest
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
 click==7.1.2
     # via pip-tools
+contextlib2==0.6.0.post1
+    # via schema
 coverage==5.5
     # via pytest-cov
 cython==0.29.22
     # via -r requirements/in/cython.in
+decorator==4.4.2
+    # via jsonpath-rw
 distlib==0.3.1
     # via virtualenv
+docker==4.4.4
+    # via appimage-builder
 easyprocess==0.3
     # via pyvirtualdisplay
+emrichen==0.2.3
+    # via appimage-builder
 filelock==3.0.12
     # via
     #   tox
@@ -22,16 +36,21 @@ flake8==3.8.4
     # via -r requirements/in/dev.in
 graphviz==0.16
     # via objgraph
+idna==2.10
+    # via requests
 iniconfig==1.1.1
     # via pytest
 jpype1==1.2.1
     # via -r requirements/in/base.in
+jsonpath-rw==1.4.0
+    # via emrichen
 mccabe==0.6.1
     # via flake8
 objgraph==3.5.0
     # via -r requirements/in/dev.in
 packaging==20.9
     # via
+    #   appimage-builder
     #   pytest
     #   tox
 pillow==8.1.1
@@ -42,12 +61,18 @@ pluggy==0.13.1
     # via
     #   pytest
     #   tox
+ply==3.11
+    # via jsonpath-rw
+prompt-toolkit==3.0.18
+    # via questionary
 py-cpuinfo==7.0.0
     # via pytest-benchmark
 py==1.10.0
     # via
     #   pytest
     #   tox
+pyaml==20.4.0
+    # via emrichen
 pycodestyle==2.6.0
     # via flake8
 pyflakes==2.2.0
@@ -88,12 +113,28 @@ pytest==6.2.2
     #   pytest-xvfb
 pyvirtualdisplay==2.1
     # via pytest-xvfb
+pyyaml==5.4.1
+    # via
+    #   appimage-builder
+    #   emrichen
+    #   pyaml
+questionary==1.9.0
+    # via appimage-builder
+requests==2.25.1
+    # via
+    #   appimage-builder
+    #   docker
 rfc3987==1.3.8
     # via -r requirements/in/base.in
+schema==0.7.4
+    # via appimage-builder
 six==1.15.0
     # via
+    #   docker
+    #   jsonpath-rw
     #   tox
     #   virtualenv
+    #   websocket-client
 toml==0.10.2
     # via
     #   pytest
@@ -104,8 +145,14 @@ tox==3.22.0
     # via
     #   -r requirements/in/tox.in
     #   tox-factor
+urllib3==1.26.4
+    # via requests
 virtualenv==20.4.2
     # via tox
+wcwidth==0.2.5
+    # via prompt-toolkit
+websocket-client==0.58.0
+    # via docker
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/out/requirements-py39-linux.txt
+++ b/requirements/out/requirements-py39-linux.txt
@@ -2,18 +2,32 @@ altgraph==0.17
     # via pyinstaller
 appdirs==1.4.4
     # via virtualenv
+appimage-builder==0.8.7 ; sys_platform == "linux"
+    # via -r requirements/in/packaging.in
 attrs==20.3.0
     # via pytest
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
 click==7.1.2
     # via pip-tools
+contextlib2==0.6.0.post1
+    # via schema
 coverage==5.5
     # via pytest-cov
 cython==0.29.22
     # via -r requirements/in/cython.in
+decorator==4.4.2
+    # via jsonpath-rw
 distlib==0.3.1
     # via virtualenv
+docker==4.4.4
+    # via appimage-builder
 easyprocess==0.3
     # via pyvirtualdisplay
+emrichen==0.2.3
+    # via appimage-builder
 filelock==3.0.12
     # via
     #   tox
@@ -22,16 +36,21 @@ flake8==3.8.4
     # via -r requirements/in/dev.in
 graphviz==0.16
     # via objgraph
+idna==2.10
+    # via requests
 iniconfig==1.1.1
     # via pytest
 jpype1==1.2.1
     # via -r requirements/in/base.in
+jsonpath-rw==1.4.0
+    # via emrichen
 mccabe==0.6.1
     # via flake8
 objgraph==3.5.0
     # via -r requirements/in/dev.in
 packaging==20.9
     # via
+    #   appimage-builder
     #   pytest
     #   tox
 pillow==8.1.1
@@ -42,12 +61,18 @@ pluggy==0.13.1
     # via
     #   pytest
     #   tox
+ply==3.11
+    # via jsonpath-rw
+prompt-toolkit==3.0.18
+    # via questionary
 py-cpuinfo==7.0.0
     # via pytest-benchmark
 py==1.10.0
     # via
     #   pytest
     #   tox
+pyaml==20.4.0
+    # via emrichen
 pycodestyle==2.6.0
     # via flake8
 pyflakes==2.2.0
@@ -88,12 +113,28 @@ pytest==6.2.2
     #   pytest-xvfb
 pyvirtualdisplay==2.1
     # via pytest-xvfb
+pyyaml==5.4.1
+    # via
+    #   appimage-builder
+    #   emrichen
+    #   pyaml
+questionary==1.9.0
+    # via appimage-builder
+requests==2.25.1
+    # via
+    #   appimage-builder
+    #   docker
 rfc3987==1.3.8
     # via -r requirements/in/base.in
+schema==0.7.4
+    # via appimage-builder
 six==1.15.0
     # via
+    #   docker
+    #   jsonpath-rw
     #   tox
     #   virtualenv
+    #   websocket-client
 toml==0.10.2
     # via
     #   pytest
@@ -104,8 +145,14 @@ tox==3.22.0
     # via
     #   -r requirements/in/tox.in
     #   tox-factor
+urllib3==1.26.4
+    # via requests
 virtualenv==20.4.2
     # via tox
+wcwidth==0.2.5
+    # via prompt-toolkit
+websocket-client==0.58.0
+    # via docker
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/support/appimage/AppImageBuilder.yml
+++ b/support/appimage/AppImageBuilder.yml
@@ -1,0 +1,75 @@
+version: 1
+
+script:
+  - rm -rf AppDir | true
+  - mkdir -p AppDir/usr/share/icons/hicolor/128x128/apps
+  - mkdir -p AppDir/resources/
+  - cp resources/images/eddy.png AppDir/usr/share/icons/hicolor/128x128/apps/
+  - cp -r resources/java AppDir/resources/ | true
+  # Do not ship examples with the AppImage
+  # - cp -r examples AppDir/ | true
+  - cp LICENSE AppDir/ | true
+  - cp README.md AppDir/ | true
+  - python3 -m pip install -I --prefix=/usr --root=AppDir -r ./requirements/in/base.in -r ./requirements/in/pyqt5.in
+  - python3 setup.py install --prefix=/usr --root=AppDir
+
+AppDir:
+  path: ./AppDir
+  app_info:
+    id: !ENV "${EDDY_APPIMAGE_ID}"
+    name: !ENV "${EDDY_APPIMAGE_NAME}"
+    icon: !ENV "${EDDY_APPIMAGE_ICON}"
+    version: !ENV "${EDDY_APPIMAGE_VERSION}"
+    exec: usr/bin/python3
+    exec_args: "-m eddy $@"
+  apt:
+    arch: amd64
+    sources:
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x871920d1991bc93c'
+    include:
+      - python3
+      - python3-pkg-resources
+      - libssl1.1
+      - libkrb5-3
+      - libgssapi-krb5-2
+  files:
+    exclude:
+      - usr/share/man
+      - usr/share/doc
+      - usr/share/python-wheels
+  after_bundle: |
+  runtime:
+    version: "continuous"
+    env:
+      PATH: '${APPDIR}/usr/bin:${PATH}'
+      PYTHONHOME: '${APPDIR}/usr'
+      PYTHONPATH: '${APPDIR}/usr/lib/python3.8/site-packages'
+  test:
+    fedora:
+      image: appimagecrafters/tests-env:fedora-30
+      command: ./AppRun
+      use_host_x: true
+    debian:
+      image: appimagecrafters/tests-env:debian-stable
+      command: ./AppRun
+      use_host_x: true
+    arch:
+      image: appimagecrafters/tests-env:archlinux-latest
+      command: ./AppRun
+      use_host_x: true
+    centos:
+      image: appimagecrafters/tests-env:centos-7
+      command: ./AppRun
+      use_host_x: true
+    ubuntu:
+      image: appimagecrafters/tests-env:ubuntu-xenial
+      command: ./AppRun
+      use_host_x: true
+
+AppImage:
+  update-information: None
+  sign-key: None
+  arch: x86_64


### PR DESCRIPTION
This PR add support for producing AppImages as a new format for releases on GNU/Linux.

Due to limitations with the build tools AppImages need to be built on a Debian-based distro (in particular Ubuntu 20.04), as appimage-builder needs apt-get to prepare the AppDir, and the python executable must install packages in the AppDir using the multi-arch directory structure.

Nonetheless the generated AppImages seem to be pretty stable and currently have much less ABI incompatibility issues than the builds generated with pyinstaller.