### PR TITLE
Drop uploads to Bintray and move all ci workflows to GitHub

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -58,22 +58,3 @@ jobs:
         with:
           name: Eddy-${{ runner.os }}
           path: dist/*
-
-      - run: |
-          echo EDDY_VERSION="$(python -c 'import eddy; print(eddy.VERSION)')" >> $GITHUB_ENV
-
-      - name: Upload artifact (Bintray)
-        if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          python -m pip install bintray-python==0.8.0
-          python ./scripts/bintray_upload.py \
-            --username ${{ secrets.BINTRAY_API_USER }} \
-            --api-key ${{ secrets.BINTRAY_API_KEY }} \
-            --subject ${{ secrets.BINTRAY_REPO_USER }} \
-            --repo ${{ secrets.BINTRAY_REPO}} \
-            --package Eddy \
-            --version ${{ env.EDDY_VERSION }} \
-            --prefix-path ${{ env.EDDY_VERSION }} \
-            --publish \
-            --override \
-            dist/*

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,16 +14,30 @@ jobs:
             python-version: 3.8
             architecture: x64
             appimage: true
-
           - os: ubuntu-20.04
             python-version: 3.8
             architecture: x64
             archive: true
-
           - os: macos-10.15
             python-version: 3.8
             architecture: x64
             dmg: true
+          - os: windows-2019
+            python-version: 3.8
+            architecture: x86
+            innosetup: true
+          - os: windows-2019
+            python-version: 3.8
+            architecture: x86
+            archive: true
+          - os: windows-2019
+            python-version: 3.8
+            architecture: x64
+            innosetup: true
+          - os: windows-2019
+            python-version: 3.8
+            architecture: x64
+            archive: true
 
     steps:
       - name: Checkout code
@@ -36,6 +50,7 @@ jobs:
           architecture: ${{ matrix.architecture }}
 
       - name: Bundle JRE
+        shell: bash
         run: |
           python ./scripts/getjdk.py --binary --arch ${{ matrix.architecture }} --feature-version 11 --image-type jre --extract-to resources
           mv resources/jdk* resources/java
@@ -52,36 +67,53 @@ jobs:
           sudo chmod +x /usr/local/bin/appimagetool
           python setup.py appimage --skip-tests
 
-      - name: Package application (archive)
-        if: ${{ matrix.archive }}
+      - name: Package application (innosetup)
+        if: ${{ startsWith(runner.os, 'Win') && matrix.innosetup }}
+        shell: bash
         run: |
-          find "$RUNNER_TOOL_CACHE/Python" -type f -name libqgtk3.so -delete
-          python setup.py standalone
+          export ISCC_EXE="C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+          python setup.py innosetup
 
       - name: Package application (dmg)
         if: ${{ startsWith(runner.os, 'macOS') && matrix.dmg }}
         run: |
           python setup.py createdmg
 
+      - name: Package application (archive)
+        if: ${{ matrix.archive }}
+        shell: bash
+        run: |
+          if [[ ${{ runner.os }} == 'Linux' ]]; then
+            find "$RUNNER_TOOL_CACHE/Python" -type f -name libqgtk3.so -delete
+          fi
+          python setup.py standalone
+
       - name: Upload artifact (appimage)
         uses: actions/upload-artifact@v2
         with:
-          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.architecture }}-AppImage
+          name: Eddy-${{ runner.os }}-${{ matrix.architecture }}-AppImage
           path: dist/*.AppImage
         if: ${{ matrix.appimage }}
 
-      - name: Upload artifact (archive)
+      - name: Upload artifact (innosetup)
         uses: actions/upload-artifact@v2
         with:
-          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.architecture }}-Archive
-          path: |
-            dist/*.tar.*
-            dist/*.zip
-        if: ${{ matrix.archive }}
+          name: Eddy-${{ runner.os }}-${{ matrix.architecture }}-Installer
+          path: dist/*.exe
+        if: ${{ matrix.innosetup }}
 
       - name: Upload artifact (dmg)
         uses: actions/upload-artifact@v2
         with:
-          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.architecture }}-DMG
+          name: Eddy-${{ runner.os }}-${{ matrix.architecture }}-DMG
           path: dist/*.dmg
         if: ${{ matrix.dmg }}
+
+      - name: Upload artifact (archive)
+        uses: actions/upload-artifact@v2
+        with:
+          name: Eddy-${{ runner.os }}-${{ matrix.architecture }}-Archive
+          path: |
+            dist/*.tar.*
+            dist/*.zip
+        if: ${{ matrix.archive }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,14 +12,17 @@ jobs:
         include:
           - os: ubuntu-20.04
             python-version: 3.8
+            architecture: x64
             appimage: true
 
           - os: ubuntu-20.04
             python-version: 3.8
+            architecture: x64
             archive: true
 
           - os: macos-10.15
             python-version: 3.8
+            architecture: x64
             dmg: true
 
     steps:
@@ -30,10 +33,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
 
       - name: Bundle JRE
         run: |
-          python ./scripts/getjdk.py --binary --feature-version 11 --image-type jre --extract-to resources
+          python ./scripts/getjdk.py --binary --arch ${{ matrix.architecture }} --feature-version 11 --image-type jre --extract-to resources
           mv resources/jdk* resources/java
 
       - name: Install python dependencies
@@ -62,14 +66,14 @@ jobs:
       - name: Upload artifact (appimage)
         uses: actions/upload-artifact@v2
         with:
-          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-AppImage
+          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.architecture }}-AppImage
           path: dist/*.AppImage
         if: ${{ matrix.appimage }}
 
       - name: Upload artifact (archive)
         uses: actions/upload-artifact@v2
         with:
-          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-Archive
+          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.architecture }}-Archive
           path: |
             dist/*.tar.*
             dist/*.zip
@@ -78,6 +82,6 @@ jobs:
       - name: Upload artifact (dmg)
         uses: actions/upload-artifact@v2
         with:
-          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-DMG
+          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-${{ matrix.architecture }}-DMG
           path: dist/*.dmg
         if: ${{ matrix.dmg }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -3,8 +3,8 @@ name: builds
 on: push
 
 jobs:
-  create-builds:
-    name: ${{ runner.os }} | ${{ matrix.architecture }} | ${{ matrix.type }}
+  builds:
+    name: ${{ matrix.platform }} | ${{ matrix.architecture }} | ${{ matrix.type }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -13,38 +13,45 @@ jobs:
           - os: ubuntu-20.04
             python-version: 3.8
             architecture: x64
-            appimage: true
+            platform: Linux
             type: AppImage
+            appimage: true
           - os: ubuntu-20.04
             python-version: 3.8
             architecture: x64
-            archive: true
+            platform: Linux
             type: Standalone
+            archive: true
           - os: macos-10.15
             python-version: 3.8
             architecture: x64
-            dmg: true
+            platform: macOS
             type: DMG
+            dmg: true
           - os: windows-2019
             python-version: 3.8
             architecture: x86
-            innosetup: true
+            platform: Windows
             type: Installer
+            innosetup: true
           - os: windows-2019
             python-version: 3.8
             architecture: x86
-            archive: true
+            platform: Windows
             type: Standalone
+            archive: true
           - os: windows-2019
             python-version: 3.8
             architecture: x64
-            innosetup: true
+            platform: Windows
             type: Installer
+            innosetup: true
           - os: windows-2019
             python-version: 3.8
             architecture: x64
-            archive: true
+            platform: Windows
             type: Standalone
+            archive: true
 
     steps:
       - name: Checkout code
@@ -71,7 +78,7 @@ jobs:
         shell: bash
         run: |
           if [[ ${{ matrix.archive }} == 'true' ]]; then
-            if [[ ${{ runner.os }} == 'Linux' ]]; then
+            if [[ ${{ matrix.platform }} == 'Linux' ]]; then
               # Remove GTK3 Platform theme on linux before freezing as it mostly causes
               # ABI incompatibility issues when run on other distributions.
               find "$RUNNER_TOOL_CACHE/Python" -type f -name libqgtk3.so -delete
@@ -93,7 +100,7 @@ jobs:
         shell: bash
         run: |
           SHA="$(git rev-parse --short "$GITHUB_SHA")"
-          PLATFORM="${{ runner.os }}"
+          PLATFORM="${{ matrix.platform }}"
           ARCH="${{ matrix.architecture }}"
           TYPE="${{ matrix.type }}"
           NAME="Eddy-$PLATFORM-$ARCH-$TYPE-$SHA"

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -111,3 +111,10 @@ jobs:
         with:
           name: ${{ steps.artifact-metadata.outputs.name }}
           path: dist/*
+
+      - name: Upload release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: true
+          files: dist/*

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   create-builds:
-    name: Create distributable builds
+    name: ${{ runner.os }} | ${{ matrix.architecture }} | ${{ matrix.type }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -14,30 +14,37 @@ jobs:
             python-version: 3.8
             architecture: x64
             appimage: true
+            type: AppImage
           - os: ubuntu-20.04
             python-version: 3.8
             architecture: x64
             archive: true
+            type: Standalone
           - os: macos-10.15
             python-version: 3.8
             architecture: x64
             dmg: true
+            type: DMG
           - os: windows-2019
             python-version: 3.8
             architecture: x86
             innosetup: true
+            type: Installer
           - os: windows-2019
             python-version: 3.8
             architecture: x86
             archive: true
+            type: Standalone
           - os: windows-2019
             python-version: 3.8
             architecture: x64
             innosetup: true
+            type: Installer
           - os: windows-2019
             python-version: 3.8
             architecture: x64
             archive: true
+            type: Standalone
 
     steps:
       - name: Checkout code
@@ -60,33 +67,26 @@ jobs:
           python -m pip install -U pip setuptools wheel
           python -m pip install -U -r requirements/in/dev.in
 
-      - name: Package application (appimage)
-        if: ${{ startsWith(runner.os, 'Linux') && matrix.appimage }}
-        run: |
-          sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
-          sudo chmod +x /usr/local/bin/appimagetool
-          python setup.py appimage --skip-tests
-
-      - name: Package application (innosetup)
-        if: ${{ startsWith(runner.os, 'Win') && matrix.innosetup }}
+      - name: Package application
         shell: bash
         run: |
-          export ISCC_EXE="C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
-          python setup.py innosetup
-
-      - name: Package application (dmg)
-        if: ${{ startsWith(runner.os, 'macOS') && matrix.dmg }}
-        run: |
-          python setup.py createdmg
-
-      - name: Package application (archive)
-        if: ${{ matrix.archive }}
-        shell: bash
-        run: |
-          if [[ ${{ runner.os }} == 'Linux' ]]; then
-            find "$RUNNER_TOOL_CACHE/Python" -type f -name libqgtk3.so -delete
+          if [[ ${{ matrix.archive }} == 'true' ]]; then
+            if [[ ${{ runner.os }} == 'Linux' ]]; then
+              # Remove GTK3 Platform theme on linux before freezing as it mostly causes
+              # ABI incompatibility issues when run on other distributions.
+              find "$RUNNER_TOOL_CACHE/Python" -type f -name libqgtk3.so -delete
+            fi
+            python setup.py standalone
+          elif [[ ${{ matrix.appimage }} == 'true' ]]; then
+            sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
+            sudo chmod +x /usr/local/bin/appimagetool
+            python setup.py appimage --skip-tests
+          elif [[ ${{ matrix.dmg }} == 'true' ]]; then
+            python setup.py createdmg
+          elif [[ ${{ matrix.innosetup }} == 'true' ]]; then
+            export ISCC_EXE="C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+            python setup.py innosetup
           fi
-          python setup.py standalone
 
       - name: Prepare artifact metadata
         id: artifact-metadata

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -88,32 +88,19 @@ jobs:
           fi
           python setup.py standalone
 
-      - name: Upload artifact (appimage)
-        uses: actions/upload-artifact@v2
-        with:
-          name: Eddy-${{ runner.os }}-${{ matrix.architecture }}-AppImage
-          path: dist/*.AppImage
-        if: ${{ matrix.appimage }}
+      - name: Prepare artifact metadata
+        id: artifact-metadata
+        shell: bash
+        run: |
+          SHA="$(git rev-parse --short "$GITHUB_SHA")"
+          PLATFORM="${{ runner.os }}"
+          ARCH="${{ matrix.architecture }}"
+          TYPE="${{ matrix.type }}"
+          NAME="Eddy-$PLATFORM-$ARCH-$TYPE-$SHA"
+          echo "::set-output name=name::$(echo "$NAME")"
 
-      - name: Upload artifact (innosetup)
+      - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: Eddy-${{ runner.os }}-${{ matrix.architecture }}-Installer
-          path: dist/*.exe
-        if: ${{ matrix.innosetup }}
-
-      - name: Upload artifact (dmg)
-        uses: actions/upload-artifact@v2
-        with:
-          name: Eddy-${{ runner.os }}-${{ matrix.architecture }}-DMG
-          path: dist/*.dmg
-        if: ${{ matrix.dmg }}
-
-      - name: Upload artifact (archive)
-        uses: actions/upload-artifact@v2
-        with:
-          name: Eddy-${{ runner.os }}-${{ matrix.architecture }}-Archive
-          path: |
-            dist/*.tar.*
-            dist/*.zip
-        if: ${{ matrix.archive }}
+          name: ${{ steps.artifact-metadata.outputs.name }}
+          path: dist/*

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -77,20 +77,20 @@ jobs:
       - name: Package application
         shell: bash
         run: |
-          if [[ ${{ matrix.archive }} == 'true' ]]; then
+          if [[ x${{ matrix.archive }} == 'xtrue' ]]; then
             if [[ ${{ matrix.platform }} == 'Linux' ]]; then
               # Remove GTK3 Platform theme on linux before freezing as it mostly causes
               # ABI incompatibility issues when run on other distributions.
               find "$RUNNER_TOOL_CACHE/Python" -type f -name libqgtk3.so -delete
             fi
             python setup.py standalone
-          elif [[ ${{ matrix.appimage }} == 'true' ]]; then
+          elif [[ x${{ matrix.appimage }} == 'xtrue' ]]; then
             sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
             sudo chmod +x /usr/local/bin/appimagetool
             python setup.py appimage --skip-tests
-          elif [[ ${{ matrix.dmg }} == 'true' ]]; then
+          elif [[ x${{ matrix.dmg }} == 'xtrue' ]]; then
             python setup.py createdmg
-          elif [[ ${{ matrix.innosetup }} == 'true' ]]; then
+          elif [[ x${{ matrix.innosetup }} == 'xtrue' ]]; then
             export ISCC_EXE="C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
             python setup.py innosetup
           fi

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,6 +1,6 @@
 name: builds
 
-on: push
+on: [push, pull_request]
 
 jobs:
   builds:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,9 +12,15 @@ jobs:
         include:
           - os: ubuntu-20.04
             python-version: 3.8
+            appimage: true
+
+          - os: ubuntu-20.04
+            python-version: 3.8
+            archive: true
 
           - os: macos-10.15
             python-version: 3.8
+            dmg: true
 
     steps:
       - name: Checkout code
@@ -35,26 +41,43 @@ jobs:
           python -m pip install -U pip setuptools wheel
           python -m pip install -U -r requirements/in/dev.in
 
-      - name: Package application (AppImage)
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      - name: Package application (appimage)
+        if: ${{ startsWith(runner.os, 'Linux') && matrix.appimage }}
         run: |
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
           python setup.py appimage --skip-tests
 
       - name: Package application (archive)
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if: ${{ matrix.archive }}
         run: |
           find "$RUNNER_TOOL_CACHE/Python" -type f -name libqgtk3.so -delete
           python setup.py standalone
 
       - name: Package application (dmg)
-        if: ${{ startsWith(matrix.os, 'macos') }}
+        if: ${{ startsWith(runner.os, 'macOS') && matrix.dmg }}
         run: |
           python setup.py createdmg
 
-      - name: Upload artifact (GitHub)
+      - name: Upload artifact (appimage)
         uses: actions/upload-artifact@v2
         with:
-          name: Eddy-${{ runner.os }}
-          path: dist/*
+          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-AppImage
+          path: dist/*.AppImage
+        if: ${{ matrix.appimage }}
+
+      - name: Upload artifact (archive)
+        uses: actions/upload-artifact@v2
+        with:
+          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-Archive
+          path: |
+            dist/*.tar.*
+            dist/*.zip
+        if: ${{ matrix.archive }}
+
+      - name: Upload artifact (dmg)
+        uses: actions/upload-artifact@v2
+        with:
+          name: Eddy-${{ runner.os }}-${{ matrix.platform }}-DMG
+          path: dist/*.dmg
+        if: ${{ matrix.dmg }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,8 @@ name: tests
 on: [push, pull_request]
 
 jobs:
-  run-tests:
-    name: Run unit tests
+  tests:
+    name: ${{ matrix.os }} | ${{ matrix.python-version }} | ${{ matrix.pyqt-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Eddy
 
 | Branch    | Status        |
 |-----------|---------------|
-| [master](https://github.com/obdasystems/eddy/tree/master)   |[![Tests Status](https://github.com/obdasystems/eddy/workflows/tests/badge.svg?branch=master)](https://github.com/obdasystems/eddy/actions)  [![Build Status](https://github.com/obdasystems/eddy/workflows/builds/badge.svg?branch=master)](https://github.com/obdasystems/eddy/actions)  [![Build Status](https://img.shields.io/appveyor/build/obdasystems/eddy/master?logo=appveyor)](https://ci.appveyor.com/project/obdasystems/eddy/branch/master)  |
-| [develop](https://github.com/obdasystems/eddy/tree/develop) |[![Tests Status](https://github.com/obdasystems/eddy/workflows/tests/badge.svg?branch=develop)](https://github.com/obdasystems/eddy/actions) [![Build Status](https://github.com/obdasystems/eddy/workflows/builds/badge.svg?branch=develop)](https://github.com/obdasystems/eddy/actions) [![Build Status](https://img.shields.io/appveyor/build/obdasystems/eddy/develop?logo=appveyor)](https://ci.appveyor.com/project/obdasystems/eddy/branch/develop)|
+| [master](https://github.com/obdasystems/eddy/tree/master)   |[![Tests Status](https://github.com/obdasystems/eddy/workflows/tests/badge.svg?branch=master)](https://github.com/obdasystems/eddy/actions)  [![Build Status](https://github.com/obdasystems/eddy/workflows/builds/badge.svg?branch=master)](https://github.com/obdasystems/eddy/actions) |
+| [develop](https://github.com/obdasystems/eddy/tree/develop) |[![Tests Status](https://github.com/obdasystems/eddy/workflows/tests/badge.svg?branch=develop)](https://github.com/obdasystems/eddy/actions) [![Build Status](https://github.com/obdasystems/eddy/workflows/builds/badge.svg?branch=develop)](https://github.com/obdasystems/eddy/actions)|
 
 Eddy is a graphical editor for the specification and visualization of Graphol ontologies.
 Eddy features a design environment specifically thought out for generating Graphol ontologies through


### PR DESCRIPTION
Bintray has been sunset on May 1st 2021, so uploads there are not possible anymore.

This PR drops all artifact uploads to Bintray. Also, since GitHub provides runners for all
supported platform, this moves all the other CI workflows there by adding build workflows
for Windows.
This means that all the infrastructure for the project is now hosted entirely on GitHub.

Old workflows are still in place, but have been disabled.