### PR TITLE
State-preserving file dialog and saveAs behaviour

### DIFF
--- a/eddy/ui/file.py
+++ b/eddy/ui/file.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+
+##########################################################################
+#                                                                        #
+#  Eddy: a graphical editor for the specification of Graphol ontologies  #
+#  Copyright (C) 2015 Daniele Pantaleone <danielepantaleone@me.com>      #
+#                                                                        #
+#  This program is free software: you can redistribute it and/or modify  #
+#  it under the terms of the GNU General Public License as published by  #
+#  the Free Software Foundation, either version 3 of the License, or     #
+#  (at your option) any later version.                                   #
+#                                                                        #
+#  This program is distributed in the hope that it will be useful,       #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of        #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          #
+#  GNU General Public License for more details.                          #
+#                                                                        #
+#  You should have received a copy of the GNU General Public License     #
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.  #
+#                                                                        #
+#  #####################                          #####################  #
+#                                                                        #
+#  Graphol is developed by members of the DASI-lab group of the          #
+#  Dipartimento di Ingegneria Informatica, Automatica e Gestionale       #
+#  A.Ruberti at Sapienza University of Rome: http://www.dis.uniroma1.it  #
+#                                                                        #
+#     - Domenico Lembo <lembo@dis.uniroma1.it>                           #
+#     - Valerio Santarelli <santarelli@dis.uniroma1.it>                  #
+#     - Domenico Fabio Savo <savo@dis.uniroma1.it>                       #
+#     - Daniele Pantaleone <pantaleone@dis.uniroma1.it>                  #
+#     - Marco Console <console@dis.uniroma1.it>                          #
+#                                                                        #
+##########################################################################
+
+
+from typing import Any
+
+from PyQt5 import (
+    QtCore,
+    QtGui,
+    QtWidgets,
+)
+
+from eddy.core.datatypes.system import File
+from eddy.core.functions.signals import connect
+
+
+class FileDialog(QtWidgets.QFileDialog):
+    """
+    Extends `QtWidgets.QFileDialog` to provide a file dialog that remembers
+    its state and geometry between sessions.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """
+        Initializes the file dialog.
+        """
+        super().__init__(*args, **kwargs)
+        # RESTORE STATE AND GEOMETRY
+        settings = QtCore.QSettings()
+        self.restoreGeometry(settings.value('filedialog/geometry', QtCore.QByteArray()))
+        self.restoreState(settings.value('filedialog/state', QtCore.QByteArray()))
+        self.setDirectoryUrl(settings.value('filedialog/lastVisited', self.directoryUrl()))
+        connect(self.filterSelected, self.onFilterSelected)
+
+    #############################################
+    #   EVENTS
+    #################################
+
+    def hideEvent(self, hideEvent: QtGui.QHideEvent) -> None:
+        """
+        Executed when the dialog is hidden.
+        """
+        if not hideEvent.spontaneous():
+            # SAVE STATE AND GEOMETRY
+            settings = QtCore.QSettings()
+            settings.setValue('filedialog/geometry', self.saveGeometry())
+            settings.setValue('filedialog/state', self.saveState())
+            settings.setValue('filedialog/lastVisited', self.directoryUrl())
+            settings.sync()
+        super().hideEvent(hideEvent)
+
+    #############################################
+    #   SLOTS
+    #################################
+
+    @QtCore.pyqtSlot(str)
+    def onFilterSelected(self, filter: str) -> None:
+        """
+        Executed when the current file filter changes.
+        """
+        filetype = File.forValue(filter)
+        self.setDefaultSuffix(filetype.extension if filetype else '')

--- a/eddy/ui/import_ontology.py
+++ b/eddy/ui/import_ontology.py
@@ -6,15 +6,16 @@ from PyQt5.QtWidgets import QRadioButton, QButtonGroup, QAbstractButton
 
 from eddy.core.commands.project import CommandProjectAddOntologyImport
 from eddy.core.common import HasWidgetSystem, HasThreadingSystem
-from eddy.core.datatypes.qt import Font
 from eddy.core.functions.misc import first
 from eddy.core.functions.signals import connect
 from eddy.core.loaders.owl2 import OwlOntologyImportWorker
 from eddy.core.output import getLogger
 from eddy.core.owl import ImportedOntology
 from eddy.ui.fields import StringField
+from eddy.ui.file import FileDialog
 
 LOGGER = getLogger()
+
 
 class ImportOntologyDialog(QtWidgets.QDialog, HasWidgetSystem, HasThreadingSystem):
     sgnOntologyImportAccepted = QtCore.pyqtSignal(ImportedOntology)
@@ -410,21 +411,21 @@ class LocalFileWidget(QtWidgets.QWidget):
             self.pathField.setStyleSheet("color: red;")
 
     @QtCore.pyqtSlot(bool)
-    def onBrowseClicked(self,  _):
+    def onBrowseClicked(self, _):
         """
         Back button pressed
         :type _: bool
         """
         self.browseBtn.setDown(False)
-        dialog = QtWidgets.QFileDialog(self)
+        dialog = FileDialog(self)
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptOpen)
         dialog.setFileMode(QtWidgets.QFileDialog.ExistingFile)
-        dialog.setViewMode(QtWidgets.QFileDialog.Detail)
         dialog.setNameFilter("OWL files (*.owl)")
         if dialog.exec_() == QtWidgets.QFileDialog.Accepted:
             path = first(dialog.selectedFiles())
             if path:
                 self.pathField.setText(path)
+
 
 class WebFileWidget(QtWidgets.QWidget):
     sgnValidURI = QtCore.pyqtSignal()

--- a/eddy/ui/plugin.py
+++ b/eddy/ui/plugin.py
@@ -33,23 +33,30 @@
 ##########################################################################
 
 
-import os
-
 from textwrap import dedent
 
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
+from PyQt5 import (
+    QtCore,
+    QtGui,
+    QtWidgets,
+)
 
 from eddy import APPNAME
-from eddy.core.functions.misc import first, format_exception, isEmpty
-from eddy.core.functions.path import expandPath, isPathValid
+from eddy.core.datatypes.qt import Font
+from eddy.core.datatypes.system import File
+from eddy.core.functions.misc import (
+    first,
+    format_exception,
+    isEmpty,
+)
+from eddy.core.functions.path import (
+    expandPath,
+    isPathValid,
+)
 from eddy.core.functions.signals import connect
 from eddy.core.output import getLogger
-from eddy.core.datatypes.system import File
-from eddy.core.datatypes.qt import Font
-
 from eddy.ui.fields import StringField
+from eddy.ui.file import FileDialog
 
 LOGGER = getLogger()
 
@@ -194,15 +201,9 @@ class PluginInstallDialog(QtWidgets.QDialog):
         """
         Bring up a modal window that allows the user to choose a valid plugin archive.
         """
-        path = os.path.dirname(self.pluginField.value())
-        if not isPathValid(path):
-            path = expandPath('~')
-
-        dialog = QtWidgets.QFileDialog(self)
+        dialog = FileDialog(self)
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptOpen)
-        dialog.setDirectory(path)
         dialog.setFileMode(QtWidgets.QFileDialog.ExistingFile)
-        dialog.setViewMode(QtWidgets.QFileDialog.Detail)
         dialog.setNameFilters([File.Zip.value])
 
         if dialog.exec_() == QtWidgets.QFileDialog.Accepted:

--- a/eddy/ui/preferences.py
+++ b/eddy/ui/preferences.py
@@ -51,6 +51,7 @@ from eddy.core.functions.signals import connect
 from eddy.ui.fields import CheckBox, StringField
 from eddy.ui.fields import ComboBox
 from eddy.ui.fields import SpinBox
+from eddy.ui.file import FileDialog
 
 
 class PreferencesDialog(QtWidgets.QDialog, HasWidgetSystem):
@@ -374,12 +375,11 @@ class PreferencesDialog(QtWidgets.QDialog, HasWidgetSystem):
         if not isPathValid(path):
             path = expandPath('~')
 
-        dialog = QtWidgets.QFileDialog(self)
+        dialog = FileDialog(self)
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptOpen)
         dialog.setDirectory(path)
         dialog.setFileMode(QtWidgets.QFileDialog.Directory)
         dialog.setOption(QtWidgets.QFileDialog.ShowDirsOnly, True)
-        dialog.setViewMode(QtWidgets.QFileDialog.Detail)
 
         if dialog.exec_() == QtWidgets.QFileDialog.Accepted:
             self.widget('workspace_field').setValue(first(dialog.selectedFiles()))

--- a/eddy/ui/session.py
+++ b/eddy/ui/session.py
@@ -661,8 +661,7 @@ class Session(
         self.addAction(QtWidgets.QAction(
             QtGui.QIcon(':/icons/24/ic_save_black'), 'Save As...', self,
             objectName='save_as', shortcut=QtGui.QKeySequence.SaveAs,
-            statusTip='Save the current project',
-            enabled=False, triggered=self.doSaveAs))
+            statusTip='Save the current project', triggered=self.doSaveAs))
 
         # self.addAction(QtWidgets.QAction(
         #    'Import...', self, objectName='import', triggered=self.doImport,
@@ -3247,7 +3246,6 @@ class Session(
         self.action('property_transitive').setChecked(isPropertyTransitiveChecked)
         self.action('property_transitive').setEnabled(isPropertyTransitiveEnabled)
         self.action('save').setEnabled(not isUndoStackClean)
-        self.action('save_as').setEnabled(not isProjectEmpty)
         self.action('select_all').setEnabled(isDiagramActive)
         self.action('send_to_back').setEnabled(isNodeSelected)
         self.action('snap_to_grid').setEnabled(isDiagramActive)

--- a/eddy/ui/session.py
+++ b/eddy/ui/session.py
@@ -200,6 +200,7 @@ from eddy.ui.explanation import (
     EmptyEntityDialog,
 )
 from eddy.ui.fields import ComboBox
+from eddy.ui.file import FileDialog
 from eddy.ui.forms import (
     CardinalityRestrictionForm,
     NewDiagramForm,
@@ -1866,9 +1867,8 @@ class Session(
         Export the current project.
         """
         if not self.project.isEmpty():
-            dialog = QtWidgets.QFileDialog(self)
+            dialog = FileDialog(self)
             dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
-            dialog.setDirectory(expandPath('~/'))
             dialog.setFileMode(QtWidgets.QFileDialog.AnyFile)
             dialog.setNameFilters(
                 # self.ontologyExporterNameFilters()                -> .owl
@@ -1878,7 +1878,6 @@ class Session(
                        + self.diagramExporterNameFilters({File.Pdf, File.GraphML})
                        ))
 
-            dialog.setViewMode(QtWidgets.QFileDialog.Detail)
             dialog.selectFile(self.project.name)
             dialog.selectNameFilter(File.Owl.value)
             if dialog.exec_():
@@ -1902,14 +1901,12 @@ class Session(
         Export the current project diagrams.
         """
         if not self.project.isEmpty():
-            dialog = QtWidgets.QFileDialog(self)
+            dialog = FileDialog(self)
             dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
-            dialog.setDirectory(expandPath('~/'))
             dialog.setFileMode(QtWidgets.QFileDialog.AnyFile)
             # dialog.setNameFilters(self.projectExporterNameFilters({File.Graphol,File.Csv,File.GraphReferences}) + self.diagramExporterNameFilters({File.GraphML}))
             dialog.setNameFilters(self.projectExporterNameFilters(
                 {File.Csv, File.GraphReferences}) + self.diagramExporterNameFilters({File.GraphML}))
-            dialog.setViewMode(QtWidgets.QFileDialog.Detail)
             dialog.selectFile(self.project.name)
             dialog.selectNameFilter(File.Pdf.value)
             if dialog.testOption(QtWidgets.QFileDialog.DontUseNativeDialog) or not IS_MACOS:
@@ -1984,12 +1981,10 @@ class Session(
         Export the current project.
         """
         if not self.project.isEmpty():
-            dialog = QtWidgets.QFileDialog(self)
+            dialog = FileDialog(self)
             dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
-            dialog.setDirectory(expandPath('~/'))
             dialog.setFileMode(QtWidgets.QFileDialog.AnyFile)
             dialog.setNameFilters(sorted(self.ontologyExporterNameFilters()))
-            dialog.setViewMode(QtWidgets.QFileDialog.Detail)
             dialog.selectFile(self.project.name)
             dialog.selectNameFilter(File.Owl.value)
             if dialog.testOption(QtWidgets.QFileDialog.DontUseNativeDialog) or not IS_MACOS:
@@ -2052,11 +2047,9 @@ class Session(
         """
         Import an ontology into the currently active Project.
         """
-        dialog = QtWidgets.QFileDialog(self)
+        dialog = FileDialog(self)
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptOpen)
-        dialog.setDirectory(expandPath('~'))
         dialog.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
-        dialog.setViewMode(QtWidgets.QFileDialog.Detail)
         dialog.setNameFilters(self.ontologyLoaderNameFilters({File.GraphML}))
         if dialog.exec_():
             filetype = File.valueOf(dialog.selectedNameFilter())
@@ -2180,11 +2173,9 @@ class Session(
         """
         Open a project in a new session.
         """
-        dialog = QtWidgets.QFileDialog(self)
+        dialog = FileDialog(self)
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptOpen)
-        dialog.setDirectory(expandPath('~'))
         dialog.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
-        dialog.setViewMode(QtWidgets.QFileDialog.Detail)
         dialog.setNameFilters([File.Graphol.value])
         if dialog.exec_() == QtWidgets.QFileDialog.Accepted:
             self.app.sgnCreateSession.emit(expandPath(first(dialog.selectedFiles())))
@@ -2682,9 +2673,8 @@ class Session(
                     settings.sync()
             else:
                 if self.project.diagrams():
-                    dialog = QtWidgets.QFileDialog(self)
+                    dialog = FileDialog(self)
                     dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
-                    dialog.setDirectory(expandPath('~/'))
                     dialog.setFileMode(QtWidgets.QFileDialog.AnyFile)
                     # dialog.setNameFilters(sorted(self.ontologyExporterNameFilters()))
                     dialog.setNameFilter(File.Graphol.value)
@@ -2737,12 +2727,8 @@ class Session(
         """
         try:
             workingPath = self.project.path if self.project.path else None
-            dialog = QtWidgets.QFileDialog(self)
+            dialog = FileDialog(self)
             dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
-            if workingPath:
-                dialog.setDirectory(expandPath(workingPath))
-            else:
-                dialog.setDirectory(expandPath('~/'))
             dialog.setFileMode(QtWidgets.QFileDialog.AnyFile)
             # dialog.setNameFilters(sorted(self.ontologyExporterNameFilters()))
             dialog.setNameFilter(File.Graphol.value)

--- a/eddy/ui/welcome.py
+++ b/eddy/ui/welcome.py
@@ -70,6 +70,7 @@ from eddy.core.functions.path import (
     shortPath,
 )
 from eddy.core.functions.signals import connect
+from eddy.ui.file import FileDialog
 from eddy.ui.project import NewProjectDialog
 
 
@@ -296,11 +297,9 @@ class Welcome(QtWidgets.QDialog):
         """
         Bring up a modal window used to open a project.
         """
-        dialog = QtWidgets.QFileDialog(self)
+        dialog = FileDialog(self)
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptOpen)
-        dialog.setDirectory(expandPath('~'))
         dialog.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
-        dialog.setViewMode(QtWidgets.QFileDialog.Detail)
         dialog.setNameFilters([File.Graphol.value])
         if dialog.exec_() == QtWidgets.QFileDialog.Accepted:
             self.sgnOpenProject.emit(first(dialog.selectedFiles()))

--- a/eddy/ui/workspace.py
+++ b/eddy/ui/workspace.py
@@ -35,17 +35,29 @@
 
 from textwrap import dedent
 
-from PyQt5 import QtCore
-from PyQt5 import QtGui
-from PyQt5 import QtWidgets
+from PyQt5 import (
+    QtCore,
+    QtGui,
+    QtWidgets,
+)
 
-from eddy import APPNAME, WORKSPACE
+from eddy import (
+    APPNAME,
+    WORKSPACE,
+)
 from eddy.core.datatypes.qt import Font
 from eddy.core.functions.fsystem import mkdir
-from eddy.core.functions.misc import first, format_exception
-from eddy.core.functions.path import isPathValid, expandPath
+from eddy.core.functions.misc import (
+    first,
+    format_exception,
+)
+from eddy.core.functions.path import (
+    isPathValid,
+    expandPath,
+)
 from eddy.core.functions.signals import connect
 from eddy.ui.fields import StringField
+from eddy.ui.file import FileDialog
 
 
 class WorkspaceDialog(QtWidgets.QDialog):
@@ -165,12 +177,11 @@ class WorkspaceDialog(QtWidgets.QDialog):
         if not isPathValid(path):
             path = expandPath('~')
 
-        dialog = QtWidgets.QFileDialog(self)
+        dialog = FileDialog(self)
         dialog.setAcceptMode(QtWidgets.QFileDialog.AcceptOpen)
         dialog.setDirectory(path)
         dialog.setFileMode(QtWidgets.QFileDialog.Directory)
         dialog.setOption(QtWidgets.QFileDialog.ShowDirsOnly, True)
-        dialog.setViewMode(QtWidgets.QFileDialog.Detail)
 
         if dialog.exec_() == QtWidgets.QFileDialog.Accepted:
             self.workspaceField.setValue(first(dialog.selectedFiles()))


### PR DESCRIPTION
This PR addresses the following issues:

* #145: Addressed by implementing a file dialog that saves and restores its state and geometry between usages (including the last visited folder).
* #142: Addressed by switching the project path to the newly selected file when doing saveAs.