### PR TITLE
Platform-specific directories for application config and data

### DIFF
--- a/eddy/core/application.py
+++ b/eddy/core/application.py
@@ -71,6 +71,7 @@ from eddy.core.datatypes.system import (
     File,
     IS_WIN,
     IS_FROZEN,
+    IS_XDG,
 )
 from eddy.core.functions.fsystem import (
     fexists,
@@ -138,9 +139,9 @@ class Eddy(QtWidgets.QApplication):
 
         # APPLICATION INFO
         self.setDesktopFileName('{}.{}'.format(ORGANIZATION_REVERSE_DOMAIN, APPNAME))
-        self.setOrganizationName(ORGANIZATION)
+        self.setOrganizationName(ORGANIZATION.lower() if IS_XDG else ORGANIZATION)
         self.setOrganizationDomain(ORGANIZATION_DOMAIN)
-        self.setApplicationName(APPNAME)
+        self.setApplicationName(APPNAME.lower())
         self.setApplicationDisplayName(APPNAME)
         self.setApplicationVersion(VERSION)
 

--- a/eddy/core/application.py
+++ b/eddy/core/application.py
@@ -258,7 +258,7 @@ class Eddy(QtWidgets.QApplication):
         # LOOKUP PLUGINS
         #################################
 
-        PluginManager.scan('@plugins/', '@home/plugins/')
+        PluginManager.scan('@plugins/', '@data/plugins/')
 
         #############################################
         # CLOSE THE SPLASH SCREEN

--- a/eddy/core/datatypes/system.py
+++ b/eddy/core/datatypes/system.py
@@ -43,6 +43,7 @@ IS_FREEBSD = sys.platform.startswith('freebsd')
 IS_LINUX = sys.platform.startswith('linux')
 IS_MACOS = sys.platform.startswith('darwin')
 IS_WIN = sys.platform.startswith('win') or sys.platform.startswith('cygwin')
+IS_XDG = IS_LINUX or IS_FREEBSD
 
 IS_FROZEN = hasattr(sys, 'frozen')
 

--- a/eddy/core/functions/fsystem.py
+++ b/eddy/core/functions/fsystem.py
@@ -160,10 +160,11 @@ def make_archive(path, dst, base_dir=None, format='zip'):
 def mkdir(path):
     """
     Create the directory identified by the given path if it doesn't exists.
+    This method will create all intermediate-level directories if needed.
     :type path: str
     """
     if not isdir(path):
-        os.mkdir(expandPath(path))
+        os.makedirs(expandPath(path))
 
 
 def rmdir(path):

--- a/eddy/core/functions/path.py
+++ b/eddy/core/functions/path.py
@@ -60,10 +60,6 @@ __SUPPORT_PATH = os.path.join(__ROOT_PATH, 'support')
 __TESTS_PATH = os.path.join(__ROOT_PATH, 'tests')
 
 
-if not os.path.isdir(__HOME_PATH):
-    os.mkdir(__HOME_PATH)
-
-
 def compressPath(path: str, maxchars: int, dots: int = 3) -> str:
     """
     Returns a visual representation of the given path showing up to 'marchars' characters.

--- a/eddy/core/functions/path.py
+++ b/eddy/core/functions/path.py
@@ -37,6 +37,8 @@ import errno
 import os
 import sys
 
+from PyQt5 import QtCore
+
 from eddy.core.datatypes.system import (
     IS_FROZEN,
     IS_LINUX,
@@ -58,6 +60,7 @@ __PLUGINS_PATH = os.path.join(__MODULE_PATH, 'plugins')
 __RESOURCES_PATH = os.path.join(__ROOT_PATH, 'resources')
 __SUPPORT_PATH = os.path.join(__ROOT_PATH, 'support')
 __TESTS_PATH = os.path.join(__ROOT_PATH, 'tests')
+__TEST_RESOURCES_PATH = os.path.join(__TESTS_PATH, 'test_resources')
 
 
 def compressPath(path: str, maxchars: int, dots: int = 3) -> str:
@@ -80,12 +83,18 @@ def expandPath(path: str) -> str:
 
         - @eddy => Eddy's directory
         - @home => Eddy's home directory (.eddy in $HOME)
+        - @config => Eddy's config directory (platform-specific)
+        - @cache => Eddy's cache directory (platform-specific)
+        - @data => Eddy's data directory (platform-specific)
+        - @temp => Eddy's temp directory (platform-specific)
+        - @runtime => Eddy's runtime directory (platform-specific)
         - @root => Eddy's root (matches @eddy if running a frozen application)
         - @resources => Eddy's resources directory
         - @examples => Eddy's examples directory
         - @plugins => Eddy's plugins directory
         - @support => Eddy's support directory
         - @tests => Eddy's tests directory
+        - @test_resources => Eddy's test resources directory
         - ~ => will be expanded to the user home directory ($HOME)
 
     """
@@ -93,6 +102,21 @@ def expandPath(path: str) -> str:
         path = os.path.join(__MODULE_PATH, path[6:])
     elif path.startswith('@home/') or path.startswith('@home\\'):
         path = os.path.join(__HOME_PATH, path[6:])
+    elif path.startswith('@config/') or path.startswith('@config\\'):
+        confPath = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.AppConfigLocation)
+        path = os.path.join(os.path.normpath(os.path.join(confPath, os.path.pardir)), path[8:])
+    elif path.startswith('@cache/') or path.startswith('@cache\\'):
+        cachePath = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.CacheLocation)
+        path = os.path.join(os.path.normpath(os.path.join(cachePath, os.path.pardir)), path[7:])
+    elif path.startswith('@data/') or path.startswith('@data\\'):
+        dataPath = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.AppDataLocation)
+        path = os.path.join(os.path.normpath(os.path.join(dataPath, os.path.pardir)), path[6:])
+    elif path.startswith('@temp/') or path.startswith('@temp\\'):
+        tempPath = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.TempLocation)
+        path = os.path.join(tempPath, path[6:])
+    elif path.startswith('@runtime/') or path.startswith('@runtime\\'):
+        runPath = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.RuntimeLocation)
+        path = os.path.join(runPath, path[9:])
     elif path.startswith('@root/') or path.startswith('@root\\'):
         path = os.path.join(__ROOT_PATH, path[6:])
     elif path.startswith('@resources/') or path.startswith('@resources\\'):
@@ -105,6 +129,8 @@ def expandPath(path: str) -> str:
         path = os.path.join(__SUPPORT_PATH, path[9:])
     elif path.startswith('@tests/') or path.startswith('@tests\\'):
         path = os.path.join(__TESTS_PATH, path[7:])
+    elif path.startswith('@test_resources/') or path.startswith('@test_resources\\'):
+        path = os.path.join(__TEST_RESOURCES_PATH, path[16:])
     return os.path.abspath(os.path.normpath(os.path.expanduser(path)))
 
 

--- a/eddy/core/functions/path.py
+++ b/eddy/core/functions/path.py
@@ -64,12 +64,9 @@ if not os.path.isdir(__HOME_PATH):
     os.mkdir(__HOME_PATH)
 
 
-def compressPath(path, maxchars, dots=3):
+def compressPath(path: str, maxchars: int, dots: int = 3) -> str:
     """
     Returns a visual representation of the given path showing up to 'marchars' characters.
-    :type path: str
-    :type maxchars: int
-    :type dots: int
     """
     if len(path) > maxchars:
         index = path.rfind(os.path.sep)
@@ -80,7 +77,7 @@ def compressPath(path, maxchars, dots=3):
     return path
 
 
-def expandPath(path):
+def expandPath(path: str) -> str:
     """
     Return an absolute path by expanding the given relative one.
     The following tokens will be expanded:
@@ -95,8 +92,6 @@ def expandPath(path):
         - @tests => Eddy's tests directory
         - ~ => will be expanded to the user home directory ($HOME)
 
-    :type path: str
-    :rtype: str
     """
     if path.startswith('@eddy/') or path.startswith('@eddy\\'):
         path = os.path.join(__MODULE_PATH, path[6:])
@@ -117,11 +112,9 @@ def expandPath(path):
     return os.path.abspath(os.path.normpath(os.path.expanduser(path)))
 
 
-def isPathValid(path):
+def isPathValid(path: str) -> bool:
     """
     Returns True if the given path is valid, False otherwise.
-    :type path: str
-    :rtype: bool
     """
     try:
         if not path or not isinstance(path, str):
@@ -148,20 +141,16 @@ def isPathValid(path):
         return True
 
 
-def isSubPath(path1, path2):
+def isSubPath(path1: str, path2: str) -> bool:
     """
     Check whether the given 'path1' is subpath of the given 'path2'.
-    :param path1: str
-    :param path2: str
-    :rtype: bool
     """
     return expandPath(path2).startswith(expandPath(path1))
 
 
-def openPath(path):
+def openPath(path: str) -> None:
     """
     Open the given path using the OS default program.
-    :type path: str
     """
     path = expandPath(path)
     if os.path.isfile(path) or os.path.isdir(path):
@@ -173,15 +162,13 @@ def openPath(path):
             os.system('xdg-open "{0}"'.format(path))
 
 
-def shortPath(path):
+def shortPath(path: str) -> str:
     """
     Convert the given path into a short one.
     The following tokens will be reintroduced:
 
         - ~ => user home directory ($HOME)
 
-    :type path: str
-    :rtype: str
     """
     for prefix in ('~',):
         absprefix = expandPath(prefix)
@@ -190,13 +177,9 @@ def shortPath(path):
     return path
 
 
-def uniquePath(base, name, extension):
+def uniquePath(base: str, name: str, extension: str) -> str:
     """
     This function generates a unique filepath which ensure not to overwrite an existing file.
-    :type base: str
-    :type name: str
-    :type extension: str
-    :rtype: str
     """
     num = 0
     base = expandPath(base)

--- a/eddy/core/plugin.py
+++ b/eddy/core/plugin.py
@@ -182,9 +182,13 @@ class AbstractPlugin(
         """
         Returns the path to the the plugin (either a directory of a ZIP file).
         """
-        path = lstrip(inspect.getfile(self.__class__), expandPath('@plugins/'), expandPath('@home/plugins/'))
+        path = lstrip(
+            inspect.getfile(self.__class__),
+            expandPath('@plugins/'),
+            expandPath('@data/plugins/'),
+        )
         home = first(filter(None, path.split(os.path.sep)))
-        root = expandPath('@plugins/' if self.isBuiltIn() else '@home/plugins/')
+        root = expandPath('@plugins/' if self.isBuiltIn() else '@data/plugins/')
         return os.path.join(root, home)
 
     @classmethod
@@ -517,8 +521,8 @@ class PluginManager(QtCore.QObject):
                 raise PluginError('plugin %s (id: %s) is already installed' % (plugin_name, plugin_id))
 
             # COPY THE PLUGIN
-            mkdir('@home/plugins/')
-            fcopy(archive, '@home/plugins/')
+            mkdir('@data/plugins/')
+            fcopy(archive, '@data/plugins/')
 
         except Exception as e:
             LOGGER.error('Failed to install plugin: %s', e, exc_info=not isinstance(e, PluginError))


### PR DESCRIPTION
Use appropriate platform-specific locations for storing application configuration and data (currently only includes plugins) instead of a fixed .eddy folder in the user home for every supported platform.

The new paths are the following:
 * %APPDATA%\Eddy\plugins for Windows;
 * ~/Library/Application Support/Eddy/plugins for macOS;
 * $XDG_DATA_HOME/eddy/plugins for Linux (or any XDG desktop).