### PR TITLE
Pre-select OWL 2 syntax based on selected output file extension

### DIFF
--- a/eddy/core/exporters/owl2.py
+++ b/eddy/core/exporters/owl2.py
@@ -211,6 +211,16 @@ class OWLOntologyExporterDialog(QtWidgets.QDialog, HasThreadingSystem, HasWidget
         for syntax in OWLSyntax:
             field.addItem(syntax.value, syntax)
         field.setCurrentIndex(0)
+        # TRY PRESET SYNTAX FIELD BASED ON FILE EXTENSION
+        if self.path:
+            if self.path.endswith('.ttl'):
+                field.setCurrentIndex(field.findData(OWLSyntax.Turtle))
+            elif self.path.endswith('.omn'):
+                field.setCurrentIndex(field.findData(OWLSyntax.Manchester))
+            elif self.path.endswith('.owx'):
+                field.setCurrentIndex(field.findData(OWLSyntax.RDF))
+            elif self.path.endswith('.ofn'):
+                field.setCurrentIndex(field.findData(OWLSyntax.Functional))
         field.setObjectName('syntax_field')
         field.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
         self.addWidget(field)


### PR DESCRIPTION
This enables to automatically pre-select the most-appropriate OWL 2
syntax based on the user-specified output file extension during export.