### PR TITLE
PEP 563 annotations

### DIFF
--- a/eddy/core/common.py
+++ b/eddy/core/common.py
@@ -33,6 +33,8 @@
 ##########################################################################
 
 
+from __future__ import annotations
+
 import time
 from typing import (
     Any,
@@ -268,7 +270,7 @@ class HasPluginSystem(object):
         self._pluginDict = {}  # type: Dict[str, AbstractPlugin]
         self._pluginList = []  # type: List[AbstractPlugin]
 
-    def addPlugin(self, plugin: 'AbstractPlugin') -> 'AbstractPlugin':
+    def addPlugin(self, plugin: AbstractPlugin) -> AbstractPlugin:
         """
         Add a plugin to the set.
         """
@@ -281,7 +283,7 @@ class HasPluginSystem(object):
         self._pluginDict[plugin.objectName()] = plugin
         return plugin
 
-    def addPlugins(self, plugins: Iterable['AbstractPlugin']) -> None:
+    def addPlugins(self, plugins: Iterable[AbstractPlugin]) -> None:
         """
         Add the given group of plugins to the set.
         """
@@ -297,9 +299,9 @@ class HasPluginSystem(object):
 
     def insertPlugin(
         self,
-        plugin: 'AbstractPlugin',
-        before: 'AbstractPlugin',
-    ) -> 'AbstractPlugin':
+        plugin: AbstractPlugin,
+        before: AbstractPlugin,
+    ) -> AbstractPlugin:
         """
         Insert the given plugin before the given one.
         """
@@ -313,8 +315,8 @@ class HasPluginSystem(object):
 
     def insertPlugins(
         self,
-        plugins: Iterable['AbstractPlugin'],
-        before: 'AbstractPlugin',
+        plugins: Iterable[AbstractPlugin],
+        before: AbstractPlugin,
     ) -> None:
         """
         Insert the given group of plugins before the given one.
@@ -322,19 +324,19 @@ class HasPluginSystem(object):
         for plugin in plugins:
             self.insertPlugin(plugin, before)
 
-    def plugin(self, objectName: str) -> 'AbstractPlugin':
+    def plugin(self, objectName: str) -> AbstractPlugin:
         """
         Returns the reference to a plugin given it's objectName.
         """
         return self._pluginDict.get(objectName, None)
 
-    def plugins(self) -> List['AbstractPlugin']:
+    def plugins(self) -> List[AbstractPlugin]:
         """
         Returns the list of plugins.
         """
         return self._pluginList
 
-    def removePlugin(self, plugin: 'AbstractPlugin') -> 'AbstractPlugin':
+    def removePlugin(self, plugin: AbstractPlugin) -> AbstractPlugin:
         """
         Removes the given plugin from the set.
         """
@@ -535,8 +537,8 @@ class HasDiagramExportSystem(object):
     def createDiagramExporter(
         self,
         filetype: File,
-        diagram: 'Diagram',
-        session: 'Session' = None,
+        diagram: Diagram,
+        session: Session = None,
     ) -> AbstractDiagramExporter:
         """
         Creates an instance of a diagram exporter for the given filetype.
@@ -655,8 +657,8 @@ class HasOntologyExportSystem(object):
     def createOntologyExporter(
         self,
         filetype: File,
-        project: 'Project',
-        session: 'Session' = None,
+        project: Project,
+        session: Session = None,
     ) -> AbstractOntologyExporter:
         """
         Creates an instance of an ontology exporter for the given filetype.
@@ -775,8 +777,8 @@ class HasProjectExportSystem(object):
     def createProjectExporter(
         self,
         filetype: File,
-        project: 'Project',
-        session: 'Session' = None,
+        project: Project,
+        session: Session = None,
         # FIXME: Remove next two parameters, they are not part of the generic API
         exportPath: str = None,
         selectDiagrams: bool = False,
@@ -899,8 +901,8 @@ class HasDiagramLoadSystem(object):
         self,
         filetype: File,
         path: str,
-        project: 'Project',
-        session: 'Session' = None,
+        project: Project,
+        session: Session = None,
     ) -> AbstractDiagramLoader:
         """
         Creates an instance of a diagram loader for the given filetype.
@@ -1020,8 +1022,8 @@ class HasOntologyLoadSystem(object):
         self,
         filetype: File,
         path: str,
-        project: 'Project',
-        session: 'Session' = None,
+        project: Project,
+        session: Session = None,
     ) -> AbstractOntologyLoader:
         """
         Creates an instance of a ontology loader for the given filetype.
@@ -1141,7 +1143,7 @@ class HasProjectLoadSystem(object):
         self,
         filetype: File,
         path: str,
-        session: 'Session' = None,
+        session: Session = None,
     ) -> AbstractProjectLoader:
         """
         Creates an instance of a diagram loader for the given filetype.

--- a/eddy/core/diagram.py
+++ b/eddy/core/diagram.py
@@ -33,6 +33,8 @@
 ##########################################################################
 
 
+from __future__ import annotations
+
 from typing import (
     cast,
     Dict,
@@ -116,7 +118,7 @@ class Diagram(QtWidgets.QGraphicsScene):
     sgnUpdated = QtCore.pyqtSignal()
 
     # noinspection PyUnresolvedReferences
-    def __init__(self, name: str, parent: 'Project') -> None:
+    def __init__(self, name: str, parent: Project) -> None:
         """
         Initialize the diagram.
         """
@@ -157,7 +159,7 @@ class Diagram(QtWidgets.QGraphicsScene):
 
     # noinspection PyUnresolvedReferences
     @classmethod
-    def create(cls, name: str, size: int, project: 'Project') -> 'Diagram':
+    def create(cls, name: str, size: int, project: Project) -> Diagram:
         """
         Build and returns a new Diagram instance, using the given parameters.
         """
@@ -173,7 +175,7 @@ class Diagram(QtWidgets.QGraphicsScene):
 
     # noinspection PyUnresolvedReferences
     @property
-    def project(self) -> 'Project':
+    def project(self) -> Project:
         """
         Returns the project this diagram belongs to.
         """
@@ -181,7 +183,7 @@ class Diagram(QtWidgets.QGraphicsScene):
 
     # noinspection PyUnresolvedReferences
     @property
-    def session(self) -> 'Session':
+    def session(self) -> Session:
         """
         Returns the session this diagram belongs to.
         """
@@ -621,7 +623,7 @@ class Diagram(QtWidgets.QGraphicsScene):
                 node.setIdentity(computed)
 
     @QtCore.pyqtSlot(QtWidgets.QGraphicsScene, QtWidgets.QGraphicsItem)
-    def onItemAdded(self, _: 'Diagram', item: AbstractItem) -> None:
+    def onItemAdded(self, _: Diagram, item: AbstractItem) -> None:
         """
         Executed whenever a connection is created/removed.
         """
@@ -635,7 +637,7 @@ class Diagram(QtWidgets.QGraphicsScene):
                     self.sgnNodeIdentification.emit(node)
 
     @QtCore.pyqtSlot(QtWidgets.QGraphicsScene, QtWidgets.QGraphicsItem)
-    def onItemRemoved(self, _: 'Diagram', item: AbstractItem) -> None:
+    def onItemRemoved(self, _: Diagram, item: AbstractItem) -> None:
         """
         Executed whenever a connection is created/removed.
         """

--- a/eddy/core/exporters/metadata.py
+++ b/eddy/core/exporters/metadata.py
@@ -33,6 +33,8 @@
 ##########################################################################
 
 
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 import csv
 import io
@@ -94,7 +96,7 @@ class AbstractMetadataExporter(AbstractProjectExporter):
         Item.RoleNode: 'Object Property',
     }
 
-    def __init__(self, project: 'Project', session: 'Session' = None, **kwargs: Any) -> None:
+    def __init__(self, project: Project, session: Session = None, **kwargs: Any) -> None:
         """
         Initialize the metadata exporter.
         """
@@ -319,7 +321,7 @@ class AnnotationSelectionDialog(HasWidgetSystem, QtWidgets.QDialog):
 
     def __init__(
         self,
-        project: 'Project',
+        project: Project,
         parent: QtWidgets.QWidget = None,
         **kwargs: Any
     ) -> None:
@@ -386,7 +388,7 @@ class AnnotationSelectionDialog(HasWidgetSystem, QtWidgets.QDialog):
     #################################
 
     @property
-    def project(self) -> 'Project':
+    def project(self) -> Project:
         """
         Returns the active project.
         """
@@ -423,7 +425,7 @@ class AnnotationListWidget(HasWidgetSystem, QtWidgets.QWidget):
 
     def __init__(
         self,
-        project: 'Project',
+        project: Project,
         parent: QtWidgets.QWidget = None,
         **kwargs: Any
     ) -> None:
@@ -490,7 +492,7 @@ class AnnotationListWidget(HasWidgetSystem, QtWidgets.QWidget):
     #################################
 
     @property
-    def project(self) -> 'Project':
+    def project(self) -> Project:
         """
         Returns the active project.
         """

--- a/eddy/core/factory.py
+++ b/eddy/core/factory.py
@@ -33,6 +33,8 @@
 ##########################################################################
 
 
+from __future__ import annotations
+
 from typing import (
     cast,
     Dict,
@@ -78,7 +80,7 @@ class MenuFactory(QtCore.QObject):
     This class can be used to produce diagram items contextual menus.
     """
 
-    def __init__(self, session: 'Session') -> None:
+    def __init__(self, session: Session) -> None:
         """
         Initialize the factory.
         """
@@ -99,14 +101,14 @@ class MenuFactory(QtCore.QObject):
     #################################
 
     @property
-    def project(self) -> 'Project':
+    def project(self) -> Project:
         """
         Returns the project loaded in the active session.
         """
         return self.session.project
 
     @property
-    def session(self) -> 'Session':
+    def session(self) -> Session:
         """
         Returns the reference to the currently active session.
         """
@@ -771,7 +773,7 @@ class MenuFactory(QtCore.QObject):
 
     def create(
         self,
-        diagram: 'Diagram',
+        diagram: Diagram,
         items: Sequence[AbstractItem],
         pos: QtCore.QPointF = None,
     ) -> QtWidgets.QMenu:
@@ -854,7 +856,7 @@ class PropertyFactory(QtCore.QObject):
     This class can be used to produce properties dialog windows.
     """
 
-    def __init__(self, session: 'Session') -> None:
+    def __init__(self, session: Session) -> None:
         """
         Initialize the factory.
         """
@@ -865,14 +867,14 @@ class PropertyFactory(QtCore.QObject):
     #################################
 
     @property
-    def project(self) -> 'Project':
+    def project(self) -> Project:
         """
         Returns the project loaded in the active session.
         """
         return self.session.project
 
     @property
-    def session(self) -> 'Session':
+    def session(self) -> Session:
         """
         Returns the active session.
         """
@@ -882,7 +884,7 @@ class PropertyFactory(QtCore.QObject):
     #   INTERFACE
     #################################
 
-    def create(self, diagram: 'Diagram', node: AbstractNode = None) -> QtWidgets.QDialog:
+    def create(self, diagram: Diagram, node: AbstractNode = None) -> QtWidgets.QDialog:
         """
         Build and return a property dialog according to the given parameters.
         """

--- a/eddy/core/plugin.py
+++ b/eddy/core/plugin.py
@@ -33,6 +33,8 @@
 ##########################################################################
 
 
+from __future__ import annotations
+
 from abc import ABCMeta
 from configparser import (
     ConfigParser,
@@ -113,7 +115,7 @@ class AbstractPlugin(
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, spec: 'PluginSpec', session: 'Session') -> None:
+    def __init__(self, spec: PluginSpec, session: Session) -> None:
         """
         Initialize the plugin.
         """
@@ -125,14 +127,14 @@ class AbstractPlugin(
     #################################
 
     @property
-    def project(self) -> 'Project':
+    def project(self) -> Project:
         """
         Returns the reference to the active project.
         """
         return self.session.project
 
     @property
-    def session(self) -> 'Session':
+    def session(self) -> Session:
         """
         Returns the reference to the plugin session.
         """
@@ -192,7 +194,7 @@ class AbstractPlugin(
         return os.path.join(root, home)
 
     @classmethod
-    def subclasses(cls) -> List[Type['AbstractPlugin']]:
+    def subclasses(cls) -> List[Type[AbstractPlugin]]:
         """
         Returns the list of subclasses subclassing this very class.
         """
@@ -297,7 +299,7 @@ class PluginManager(QtCore.QObject):
     """
     info = {}  # type: Dict[str, Tuple]
 
-    def __init__(self, session: 'Session') -> None:
+    def __init__(self, session: Session) -> None:
         """
         Initialize the plugin manager.
         """
@@ -308,7 +310,7 @@ class PluginManager(QtCore.QObject):
     #################################
 
     @property
-    def session(self) -> 'Session':
+    def session(self) -> Session:
         """
         Returns the reference to the plugin manager session.
         """
@@ -346,7 +348,7 @@ class PluginManager(QtCore.QObject):
             return True
 
     @classmethod
-    def find_class(cls, mod: 'ModuleType', name: str) -> Type[AbstractPlugin]:
+    def find_class(cls, mod: ModuleType, name: str) -> Type[AbstractPlugin]:
         """
         Find and returns the reference to the plugin class in the given module.
         """
@@ -407,7 +409,7 @@ class PluginManager(QtCore.QObject):
             LOGGER.exception('Failed to import plugin: %s', e)
 
     @classmethod
-    def import_plugin_from_entry_point(cls, entry_point: 'EntryPoint') -> Tuple:
+    def import_plugin_from_entry_point(cls, entry_point: EntryPoint) -> Tuple:
         """
         Import a plugin from the given entry point:
         * Lookup for the plugin .spec configuration file from the entry point distribution.

--- a/eddy/core/project.py
+++ b/eddy/core/project.py
@@ -32,6 +32,7 @@
 #                                                                        #
 ##########################################################################
 
+from __future__ import annotations
 
 from typing import (
     cast,
@@ -177,7 +178,7 @@ class Project(IRIManager):
     #################################
 
     @property
-    def session(self) -> 'Session':
+    def session(self) -> Session:
         """
         Returns the reference to the project session.
         """

--- a/eddy/ui/iri.py
+++ b/eddy/ui/iri.py
@@ -33,6 +33,8 @@
 ##########################################################################
 
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from PyQt5 import (
@@ -240,7 +242,7 @@ class IriBuilderDialog(QtWidgets.QDialog, HasWidgetSystem):
         self,
         node: AbstractNode,
         diagram: Diagram,
-        session: 'Session',
+        session: Session,
     ) -> None:
         """
         Initialize the IRI builder dialog.


### PR DESCRIPTION
Now that python 3.7 is required to run Eddy, we can start making use of [PEP 563](https://www.python.org/dev/peps/pep-0563/) postponed evaluation of annotations.