### PR TITLE
Opt out of dark theme on macOS

### DIFF
--- a/eddy.spec
+++ b/eddy.spec
@@ -248,6 +248,7 @@ info_plist = {
     'CFBundleExecutable': APPNAME,
     'NSPrincipalClass': 'NSApplication',
     'NSHighResolutionCapable': 'True',
+    'NSRequiresAquaSystemAppearance': 'True',
     'CFBundleDocumentTypes': [{
         'CFBundleTypeName': 'Graphol File',
         'CFBundleTypeRole': 'Editor',


### PR DESCRIPTION
There is some work to do to properly support the dark theme on macOS 10.15+, like preparing a dark variant of the stylesheet and icon set and setting up an auto-detection mechanism.
This PR temporarily disables it for builds using the `NSRequiresAquaSystemAppearance` key so that at least it can be used without forcing the user to switch to a light theme variant.

See #175