### PR TITLE
Migrate from XlsxWriter to openpyxl

### DIFF
--- a/requirements/in/base.in
+++ b/requirements/in/base.in
@@ -1,4 +1,4 @@
 # From PyPi
 rfc3987==1.3.8
 jpype1==1.3.0
-XlsxWriter==3.0.3
+openpyxl==3.0.9

--- a/requirements/out/requirements-py310-linux.txt
+++ b/requirements/out/requirements-py310-linux.txt
@@ -24,6 +24,8 @@ docker==5.0.3
     # via appimage-builder
 emrichen==0.2.3
     # via appimage-builder
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -48,6 +50,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in/base.in
 packaging==21.3
     # via
     #   appimage-builder
@@ -169,8 +173,6 @@ websocket-client==1.3.2
     # via docker
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/out/requirements-py310-macos.txt
+++ b/requirements/out/requirements-py310-macos.txt
@@ -16,6 +16,8 @@ dmgbuild==1.5.2 ; sys_platform == "darwin"
     # via -r requirements/in/packaging.in
 ds-store==1.3.0
     # via dmgbuild
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -42,6 +44,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in/base.in
 packaging==21.3
     # via
     #   pytest
@@ -132,8 +136,6 @@ virtualenv==20.14.1
     # via tox
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/out/requirements-py310-winnt.txt
+++ b/requirements/out/requirements-py310-winnt.txt
@@ -17,6 +17,8 @@ cython==0.29.28
     # via -r requirements/in\cython.in
 distlib==0.3.4
     # via virtualenv
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -39,6 +41,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in\base.in
 packaging==21.3
     # via
     #   pytest
@@ -128,8 +132,6 @@ virtualenv==20.14.1
     # via tox
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in\base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/out/requirements-py37-linux.txt
+++ b/requirements/out/requirements-py37-linux.txt
@@ -24,6 +24,8 @@ docker==5.0.3
     # via appimage-builder
 emrichen==0.2.3
     # via appimage-builder
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -58,6 +60,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in/base.in
 packaging==21.3
     # via
     #   appimage-builder
@@ -184,8 +188,6 @@ websocket-client==1.3.2
     # via docker
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in/base.in
 zipp==3.8.0
     # via
     #   importlib-metadata

--- a/requirements/out/requirements-py37-macos.txt
+++ b/requirements/out/requirements-py37-macos.txt
@@ -16,6 +16,8 @@ dmgbuild==1.5.2 ; sys_platform == "darwin"
     # via -r requirements/in/packaging.in
 ds-store==1.3.0
     # via dmgbuild
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -52,6 +54,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in/base.in
 packaging==21.3
     # via
     #   pytest
@@ -147,8 +151,6 @@ virtualenv==20.14.1
     # via tox
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in/base.in
 zipp==3.8.0
     # via
     #   importlib-metadata

--- a/requirements/out/requirements-py37-winnt.txt
+++ b/requirements/out/requirements-py37-winnt.txt
@@ -17,6 +17,8 @@ cython==0.29.28
     # via -r requirements/in\cython.in
 distlib==0.3.4
     # via virtualenv
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -49,6 +51,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in\base.in
 packaging==21.3
     # via
     #   pytest
@@ -143,8 +147,6 @@ virtualenv==20.14.1
     # via tox
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in\base.in
 zipp==3.8.0
     # via
     #   importlib-metadata

--- a/requirements/out/requirements-py38-linux.txt
+++ b/requirements/out/requirements-py38-linux.txt
@@ -24,6 +24,8 @@ docker==5.0.3
     # via appimage-builder
 emrichen==0.2.3
     # via appimage-builder
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -48,6 +50,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in/base.in
 packaging==21.3
     # via
     #   appimage-builder
@@ -169,8 +173,6 @@ websocket-client==1.3.2
     # via docker
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/out/requirements-py38-macos.txt
+++ b/requirements/out/requirements-py38-macos.txt
@@ -16,6 +16,8 @@ dmgbuild==1.5.2 ; sys_platform == "darwin"
     # via -r requirements/in/packaging.in
 ds-store==1.3.0
     # via dmgbuild
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -42,6 +44,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in/base.in
 packaging==21.3
     # via
     #   pytest
@@ -132,8 +136,6 @@ virtualenv==20.14.1
     # via tox
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/out/requirements-py38-winnt.txt
+++ b/requirements/out/requirements-py38-winnt.txt
@@ -17,6 +17,8 @@ cython==0.29.28
     # via -r requirements/in\cython.in
 distlib==0.3.4
     # via virtualenv
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -39,6 +41,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in\base.in
 packaging==21.3
     # via
     #   pytest
@@ -128,8 +132,6 @@ virtualenv==20.14.1
     # via tox
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in\base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/out/requirements-py39-linux.txt
+++ b/requirements/out/requirements-py39-linux.txt
@@ -24,6 +24,8 @@ docker==5.0.3
     # via appimage-builder
 emrichen==0.2.3
     # via appimage-builder
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -48,6 +50,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in/base.in
 packaging==21.3
     # via
     #   appimage-builder
@@ -169,8 +173,6 @@ websocket-client==1.3.2
     # via docker
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/out/requirements-py39-macos.txt
+++ b/requirements/out/requirements-py39-macos.txt
@@ -16,6 +16,8 @@ dmgbuild==1.5.2 ; sys_platform == "darwin"
     # via -r requirements/in/packaging.in
 ds-store==1.3.0
     # via dmgbuild
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -42,6 +44,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in/base.in
 packaging==21.3
     # via
     #   pytest
@@ -132,8 +136,6 @@ virtualenv==20.14.1
     # via tox
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/out/requirements-py39-winnt.txt
+++ b/requirements/out/requirements-py39-winnt.txt
@@ -17,6 +17,8 @@ cython==0.29.28
     # via -r requirements/in\cython.in
 distlib==0.3.4
     # via virtualenv
+et-xmlfile==1.1.0
+    # via openpyxl
 filelock==3.6.0
     # via
     #   tox
@@ -39,6 +41,8 @@ mypy-extensions==0.4.3
     # via mypy
 objgraph==3.5.0
     # via -r requirements/in/dev.in
+openpyxl==3.0.9
+    # via -r requirements/in\base.in
 packaging==21.3
     # via
     #   pytest
@@ -128,8 +132,6 @@ virtualenv==20.14.1
     # via tox
 wheel==0.37.1
     # via pip-tools
-xlsxwriter==3.0.3
-    # via -r requirements/in\base.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/setup.py
+++ b/setup.py
@@ -608,7 +608,7 @@ setuptools.setup(
     install_requires=[
         'jpype1>=0.7.1,!=0.7.2',
         'rfc3987',
-        'XlsxWriter',
+        'openpyxl',
     ],
     packages=setuptools.find_packages(exclude=['tests', 'scripts', 'support']),
     include_package_data=True,


### PR DESCRIPTION
This change only affects the annotations exporter, and is required in anticipation of the creation of a metadata loader.

 Given that xlsxwriter does not support reading existing Excel files, it is better to migrate to a different library, since carrying two dependencies just for working with Excel files is a bit overkill.

