### PR TITLE
Preserve newlines in literals during OWL 2 export

### DIFF
--- a/eddy/core/exporters/owl2.py
+++ b/eddy/core/exporters/owl2.py
@@ -698,7 +698,7 @@ class OWLOntologyExporterWorker(AbstractWorker):
         if annotation.isIRIValued():
             value = self.IRI.create(str(annotation.value))
         else:
-            lexicalForm = annotation.value.replace('\n', ' ')
+            lexicalForm = annotation.value
             if annotation.language:
                 value = self.df.getOWLLiteral(lexicalForm, annotation.language)
             else:


### PR DESCRIPTION
This removal was mostly a hack from the time when entity IRIs where entered with newlines in them for formatting purposes, and automatically-generated annotations like `rdfs:label` where also getting these newlines.