### PR TITLE
Upgrade to macOS 11 for CI builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -22,7 +22,7 @@ jobs:
             platform: Linux
             type: Standalone
             archive: true
-          - os: macos-10.15
+          - os: macos-11
             python-version: '3.8'
             architecture: x64
             platform: macOS


### PR DESCRIPTION
Looks like dmgbuild 1.6.0+ fixes the issues with macOS 11 and later so we can finally upgrade from the deprecated images for the builds.