### PR TITLE
Fix label of literal nodes not getting updated on project load

### DIFF
--- a/eddy/core/exporters/graphol_iri.py
+++ b/eddy/core/exporters/graphol_iri.py
@@ -364,8 +364,8 @@ class GrapholIRIProjectExporter(AbstractProjectExporter):
     def getDiagramDomElement(self,diagram):
         diagramEl = self.getDomElement('diagram')
         diagramEl.setAttribute('name', diagram.name)
-        diagramEl.setAttribute('width', diagram.width())
-        diagramEl.setAttribute('height', diagram.height())
+        diagramEl.setAttribute('width', int(diagram.width()))
+        diagramEl.setAttribute('height', int(diagram.height()))
         for node in sorted(diagram.nodes(), key=lambda n:n.id):
             func = self.exportFuncForItem[node.type()]
             diagramEl.appendChild(func(node))
@@ -472,10 +472,10 @@ class GrapholIRIProjectExporter(AbstractProjectExporter):
 
         position = node.mapToScene(node.textPos())
         label = self.document.createElement('label')
-        label.setAttribute('height', node.labelA.height())
-        label.setAttribute('width', node.labelA.width() + node.labelB.width())
-        label.setAttribute('x', position.x())
-        label.setAttribute('y', position.y())
+        label.setAttribute('height', int(node.labelA.height()))
+        label.setAttribute('width', int(node.labelA.width() + node.labelB.width()))
+        label.setAttribute('x', int(position.x()))
+        label.setAttribute('y', int(position.y()))
         label.appendChild(self.document.createTextNode(node.text()))
         nodeEl.appendChild(label)
         element = self.getFacetDomElement(node)
@@ -677,19 +677,12 @@ class GrapholIRIProjectExporter(AbstractProjectExporter):
         :type node: AbstractNode
         :rtype: QDomElement
         """
-        #TODO position arriva sbagliata molte volte (Dopo che si è spostata label da posizione di default)!
         position = node.mapToScene(node.textPos())
         label = self.document.createElement('label')
-        label.setAttribute('height', node.label.height())
-        label.setAttribute('width', node.label.width())
-        '''
-        if isinstance(node, ConceptNode):
-            label.setAttribute('x', position.x()-30)
-        else:
-            label.setAttribute('x', position.x())
-        '''
-        label.setAttribute('x', position.x())
-        label.setAttribute('y', position.y())
+        label.setAttribute('height', int(node.label.height()))
+        label.setAttribute('width', int(node.label.width()))
+        label.setAttribute('x', int(position.x()))
+        label.setAttribute('y', int(position.y()))
         label.setAttribute('customSize', 1 if node.label.customFont else 0)
         label.setAttribute('size', node.label.font().pixelSize())
         if labelText:
@@ -710,8 +703,8 @@ class GrapholIRIProjectExporter(AbstractProjectExporter):
 
         for p in [edge.source.anchor(edge)] + edge.breakpoints + [edge.target.anchor(edge)]:
             point = self.document.createElement('point')
-            point.setAttribute('x', p.x())
-            point.setAttribute('y', p.y())
+            point.setAttribute('x', int(p.x()))
+            point.setAttribute('y', int(p.y()))
             element.appendChild(point)
         return element
 
@@ -741,10 +734,10 @@ class GrapholIRIProjectExporter(AbstractProjectExporter):
         element.setAttribute('type', self.itemToXml[node.type()])
         element.setAttribute('color', node.brush().color().name())
         geometry = self.document.createElement('geometry')
-        geometry.setAttribute('height', node.height())
-        geometry.setAttribute('width', node.width())
-        geometry.setAttribute('x', node.pos().x())
-        geometry.setAttribute('y', node.pos().y())
+        geometry.setAttribute('height', int(node.height()))
+        geometry.setAttribute('width', int(node.width()))
+        geometry.setAttribute('x', int(node.pos().x()))
+        geometry.setAttribute('y', int(node.pos().y()))
         element.appendChild(geometry)
         return element
 

--- a/eddy/core/items/nodes/literal.py
+++ b/eddy/core/items/nodes/literal.py
@@ -98,9 +98,8 @@ class LiteralNode(AbstractResizableNode):
         self.polygon = Polygon(createPolygon(w, h), brush, pen)
 
         self._literal = literal
-        self.labelString = str(literal)
 
-        self.label = NodeLabel(template='Empty', pos=self.center, editable=False, parent=self)
+        self.label = NodeLabel(template=str(literal), pos=self.center, editable=False, parent=self)
         self.label.setAlignment(QtCore.Qt.AlignCenter)
         self.updateNode()
         self.updateTextPos()
@@ -145,12 +144,7 @@ class LiteralNode(AbstractResizableNode):
         :type literal:Literal
         """
         self._literal = literal
-        if self.diagram:
-            self.doUpdateNodeLabel()
-            self.diagram.project.sgnUpdated.emit()
-
-    def initialLabelPosition(self):
-        return self.center()
+        self.doUpdateNodeLabel()
 
     #############################################
     #   SLOTS
@@ -158,15 +152,8 @@ class LiteralNode(AbstractResizableNode):
 
     @QtCore.pyqtSlot()
     def doUpdateNodeLabel(self):
-        if self.label and not self.labelString == str(self.literal):
-            self.labelString = str(self.literal)
-            labelPos = lambda: self.label.pos()
-            self.label.diagram.removeItem(self.label)
-            self.label = NodeLabel(template=self.labelString, pos=labelPos, editable=False, parent=self)
-            self.diagram.sgnUpdated.emit()
-        else:
-            self.labelString = str(self.literal)
-            self.label = NodeLabel(template=self.labelString, pos=self.initialLabelPosition, editable=False, parent=self)
+        self.label.setText(str(self.literal))
+        if self.diagram:
             self.diagram.sgnUpdated.emit()
 
     #############################################


### PR DESCRIPTION
Fixes an issue where the label of literal nodes loaded from a graphol project file would get the default 'Empty' text rather than the proper literal value.
This also fixes an issue existing since at least v3.1 where editing and saving the literal value without any change would result in a duplicate label getting generated for the node, and an incompatibility
of the graphol exporter with python 3.10.