### PR TITLE
Project rename action

### DIFF
--- a/eddy/core/commands/project.py
+++ b/eddy/core/commands/project.py
@@ -38,6 +38,33 @@ from PyQt5 import QtWidgets
 from eddy.core.datatypes.graphol import Item
 
 
+class CommandProjectRename(QtWidgets.QUndoCommand):
+    """
+    Extends QtWidgets.QUndoCommand with facilities to rename the Project.
+    """
+    def __init__(self, undo, redo, project):
+        """
+        Initialize the command.
+        :type undo: str
+        :type redo: str
+        :type project: Project
+        """
+        super().__init__("rename project '{0}' to '{1}'".format(undo, redo))
+        self.project = project
+        self.undo = undo
+        self.redo = redo
+
+    def redo(self):
+        """redo the command"""
+        self.project.name = self.redo
+        self.project.sgnUpdated.emit()
+
+    def undo(self):
+        """undo the command"""
+        self.project.name = self.undo
+        self.project.sgnUpdated.emit()
+
+
 #############################################
 #   Ontology IRI
 #################################

--- a/eddy/ui/forms.py
+++ b/eddy/ui/forms.py
@@ -546,3 +546,42 @@ class RenameDiagramForm(AbstractDiagramForm):
         self.warnLabel.setVisible(not isEmpty(caption))
         self.confirmationBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(enabled)
         self.setFixedSize(self.sizeHint())
+
+
+class RenameProjectForm(AbstractDiagramForm):
+    """
+    This class is used to display a modal window used to rename the project.
+    """
+
+    def __init__(self, project, parent=None):
+        """
+        Initialize the new dialog.
+        :type project: Project
+        :type parent: QtWidgets.QWidget
+        """
+        super().__init__(project, parent)
+        self.project = project
+        self.nameField.setText(self.project.name)
+        self.setWindowTitle('Rename project: {0}'.format(self.project.name))
+
+    #############################################
+    #   SLOTS
+    #################################
+
+    @QtCore.pyqtSlot(str)
+    def onNameFieldChanged(self, name):
+        """
+        Executed when the content of the input field changes.
+        :type name: str
+        """
+        name = name.strip()
+        if not name:
+            caption = ''
+            enabled = False
+        else:
+            caption = ''
+            enabled = True
+        self.warnLabel.setText(caption)
+        self.warnLabel.setVisible(not isEmpty(caption))
+        self.confirmationBox.button(QtWidgets.QDialogButtonBox.Ok).setEnabled(enabled)
+        self.setFixedSize(self.sizeHint())

--- a/eddy/ui/session.py
+++ b/eddy/ui/session.py
@@ -84,6 +84,7 @@ from eddy.core.commands.nodes import (
     CommandNodeSwitchTo,
 )
 from eddy.core.commands.project import (
+    CommandProjectRename,
     CommandProjectSetProfile,
 )
 from eddy.core.common import (
@@ -215,6 +216,7 @@ from eddy.ui.forms import (
     NewDiagramForm,
     RefactorNameForm,
     RenameDiagramForm,
+    RenameProjectForm,
 )
 from eddy.ui.import_ontology import ImportOntologyDialog
 from eddy.ui.iri import (
@@ -652,6 +654,11 @@ class Session(
             self, objectName='open', shortcut=QtGui.QKeySequence.Open,
             statusTip='Open a diagram and add it to the current project',
             triggered=self.doOpen))
+
+        self.addAction(QtWidgets.QAction(
+            QtGui.QIcon(':/icons/24/ic_label_outline_black'), 'Rename...',
+            self, objectName='rename_project', statusTip='Rename project',
+            triggered=self.doRenameProject))
 
         self.addAction(QtWidgets.QAction(
             QtGui.QIcon(':/icons/24/ic_close_black'), 'Close Project', self,
@@ -2650,6 +2657,19 @@ class Session(
                 self.undostack.push(CommandDiagramRename(diagram.name, name, diagram, self.project))
 
     @QtCore.pyqtSlot()
+    def doRenameProject(self) -> None:
+        """
+        Renames a project.
+        """
+        action = self.sender()
+        project = action.data()
+        if project:
+            form = RenameProjectForm(project, self)
+            if form.exec_() == RenameProjectForm.Accepted:
+                name = form.nameField.value()
+                self.undostack.push(CommandProjectRename(project.name, name, project))
+
+    @QtCore.pyqtSlot()
     def doSave(self) -> None:
         """
         Save the current project.
@@ -3265,6 +3285,7 @@ class Session(
         self.widget('select_reasoner').setEnabled(not isProjectEmpty)
         # self.action('reset_reasoner').setEnabled(not isProjectEmpty)
         self.action('ontology_consistency_check').setEnabled(not isProjectEmpty)
+        self.setWindowTitle(self.project)
 
     @QtCore.pyqtSlot()
     def doRenderByFullIRI(self) -> None:


### PR DESCRIPTION
This is an alternative to #264 to keep the project name property for the time being and allow it to be renamed from the UI. 

The fact is that it is not clear how to deal with the case where the ontology IRI has not short form (think of suggested save file names for which we currently use the project name).

We can consider again removing it when we figure this out.